### PR TITLE
Bug/config structure tweaks

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -22,7 +22,6 @@ typedef struct Config_Location {
     std::set<HTTP_Method>            allowed_methods;
     std::map<HTTP_Code, std::string> redirect;  // Redirect to a URL using a specific HTTP code
     File_Path                        root;
-    std::map<HTTP_Code, std::string> error_page;  // Error code to URI
     bool                             autoindex;
     File_Path                        index;
     File_Path                        upload_store;
@@ -30,10 +29,11 @@ typedef struct Config_Location {
 } Config_Location;
 
 typedef struct Config_Server {
-    struct sockaddr_in           listen;
-    unsigned int                 client_max_body_size;
-    size_t                       timeout;
-    std::vector<Config_Location> location;
+    struct sockaddr_in               listen;
+    std::map<HTTP_Code, std::string> error_page;  // Error code to URI
+    unsigned int                     client_max_body_size;
+    size_t                           timeout;
+    std::vector<Config_Location>     location;
 } Config_Server;
 
 typedef struct Config {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -17,11 +17,6 @@ Config mock_config() {
 
     loc.redirect[301] = "index.html";
     loc.root = "./root";
-
-    loc.error_page[404] = "/errors/404.html";
-    loc.error_page[500] = "/errors/500.html";
-    loc.error_page[413] = "/errors/413.html";
-
     loc.index = "index.hml";
     loc.autoindex = true;
 
@@ -34,6 +29,10 @@ Config mock_config() {
     server.listen.sin_family = AF_INET;
     server.listen.sin_port = htons(8080);
     server.listen.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+
+    server.error_page[404] = "/errors/404.html";
+    server.error_page[500] = "/errors/500.html";
+    server.error_page[413] = "/errors/413.html";
 
     server.timeout = 1000;
     server.client_max_body_size = 1024 * 1024;  // 1Mb


### PR DESCRIPTION
Did a few changes to the config structure after I built a few configuration files and realized stuff:

 - Move `error_page` to location level instead of server level. This is because **we might want to configure different error pages depending on the location, not just the server**.
 - Renamed `limit_except` to `allowed_methods`. This makes it clearer and more logical, while also following the subject more closely (it specifically mentions listing *allowed* methods, not disallowed ones).