### PR TITLE
Meta: Follow new nomenclature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,16 +15,16 @@ RMFLAGS		=	-f
 
 SRCDIR		=	src
 CFILES		=	$(SRCDIR)/main.cpp \
-				$(SRCDIR)/ConfigParser/ConfigLexer.cpp \
-				$(SRCDIR)/ConfigParser/ConfigParser.cpp \
-				$(SRCDIR)/ConnectionManager/HTTP_Message.cpp \
+				$(SRCDIR)/ConfigParser/config_lexer.cpp \
+				$(SRCDIR)/ConfigParser/config_parser.cpp \
+				$(SRCDIR)/ConnectionManager/HttpMessage.cpp \
 				$(SRCDIR)/ConnectionManager/Connection.cpp \
 				$(SRCDIR)/ConnectionManager/Request.cpp \
 				$(SRCDIR)/ConnectionManager/request_parser.cpp \
 				$(SRCDIR)/ConnectionManager/Response.cpp \
 				$(SRCDIR)/ConnectionManager/ConnectionManager.cpp \
 				$(SRCDIR)/ConnectionManager/IHandler.cpp \
-				$(SRCDIR)/ConnectionManager/ConnHandler.cpp \
+				$(SRCDIR)/ConnectionManager/ConnectionHandler.cpp \
 				$(SRCDIR)/ConnectionManager/Listener.cpp \
 				$(SRCDIR)/FileManager/read.cpp \
 				$(SRCDIR)/FileManager/write.cpp \

--- a/Makefile
+++ b/Makefile
@@ -15,22 +15,22 @@ RMFLAGS		=	-f
 
 SRCDIR		=	src
 CFILES		=	$(SRCDIR)/main.cpp \
+				$(SRCDIR)/config.cpp \
 				$(SRCDIR)/ConfigParser/config_lexer.cpp \
 				$(SRCDIR)/ConfigParser/config_parser.cpp \
-				$(SRCDIR)/ConnectionManager/HttpMessage.cpp \
 				$(SRCDIR)/ConnectionManager/Connection.cpp \
+				$(SRCDIR)/ConnectionManager/ConnectionHandler.cpp \
+				$(SRCDIR)/ConnectionManager/ConnectionManager.cpp \
+				$(SRCDIR)/ConnectionManager/HttpMessage.cpp \
+				$(SRCDIR)/ConnectionManager/IHandler.cpp \
+				$(SRCDIR)/ConnectionManager/Listener.cpp \
 				$(SRCDIR)/ConnectionManager/Request.cpp \
 				$(SRCDIR)/ConnectionManager/request_parser.cpp \
 				$(SRCDIR)/ConnectionManager/Response.cpp \
-				$(SRCDIR)/ConnectionManager/ConnectionManager.cpp \
-				$(SRCDIR)/ConnectionManager/IHandler.cpp \
-				$(SRCDIR)/ConnectionManager/ConnectionHandler.cpp \
-				$(SRCDIR)/ConnectionManager/Listener.cpp \
 				$(SRCDIR)/FileManager/read.cpp \
 				$(SRCDIR)/FileManager/write.cpp \
 				$(SRCDIR)/FileManager/listing.cpp \
 				$(SRCDIR)/socket_utils.cpp \
-				$(SRCDIR)/config.cpp
 
 OBJS		=	$(CFILES:.cpp=.o)
 

--- a/include/ConfigParser.hpp
+++ b/include/ConfigParser.hpp
@@ -4,8 +4,8 @@
 #include <exception>
 #include <fstream>
 
-#include "ConfigLexer.hpp"
 #include "config.hpp"
+#include "config_lexer.hpp"
 
 class ParserError : public std::exception {
 public:
@@ -22,8 +22,8 @@ private:
 
 Config parse_file(std::ifstream&);
 
-Config          parse_config(token_iterator, token_iterator end);
-Config_Server   parse_server(token_iterator*, token_iterator end);
-Config_Location parse_location(token_iterator*, token_iterator end);
+Config         parse_config(TokenIterator, TokenIterator end);
+ConfigServer   parse_server(TokenIterator*, TokenIterator end);
+ConfigLocation parse_location(TokenIterator*, TokenIterator end);
 
 #endif

--- a/include/Connection.hpp
+++ b/include/Connection.hpp
@@ -15,27 +15,24 @@
 class Connection {
 public:
     Connection(const ConfigServer* const, int socket);
-    Connection(const Connection&);
-    const Connection& operator=(const Connection&);
     ~Connection();
 
     const Request&  request() const;
     const Response& response() const;
 
-    ssize_t        send_data();
-    ssize_t        receive_data();
-    Status_Parsing parse_request();
+    ssize_t       send_data();
+    ssize_t       receive_data();
+    ParsingStatus parse_request();
 
     void set_config(const ConfigServer* const);
     void queue_write(const std::string& data);
     bool has_pending_write() const;
 
 private:
-    void compact_read_buffer();
-
-private:
     Connection(const Connection&);
     Connection& operator=(const Connection&);
+
+    void compact_read_buffer();
 
     const ConfigServer* _config;
 

--- a/include/Connection.hpp
+++ b/include/Connection.hpp
@@ -14,7 +14,9 @@
 
 class Connection {
 public:
-    Connection(const Config_Server* const, int socket);
+    Connection(const ConfigServer* const, int socket);
+    Connection(const Connection&);
+    const Connection& operator=(const Connection&);
     ~Connection();
 
     const Request&  request() const;
@@ -24,7 +26,7 @@ public:
     ssize_t        receive_data();
     Status_Parsing parse_request();
 
-    void set_config(const Config_Server* const);
+    void set_config(const ConfigServer* const);
     void queue_write(const std::string& data);
     bool has_pending_write() const;
 
@@ -35,7 +37,7 @@ private:
     Connection(const Connection&);
     Connection& operator=(const Connection&);
 
-    const Config_Server* _config;
+    const ConfigServer* _config;
 
     Request  _request;
     Response _response;

--- a/include/ConnectionHandler.hpp
+++ b/include/ConnectionHandler.hpp
@@ -1,5 +1,5 @@
-#ifndef CONNHANDLER_HPP
-#define CONNHANDLER_HPP
+#ifndef CONNECTIONHANDLER_HPP
+#define CONNECTIONHANDLER_HPP
 
 #include <stdint.h>
 
@@ -9,10 +9,10 @@
 #include "IHandler.hpp"
 #include "config.hpp"
 
-class ConnHandler : public IHandler {
+class ConnectionHandler : public IHandler {
 public:
-    ConnHandler(const Config_Server* srv, int client_fd);
-    virtual ~ConnHandler();
+    ConnectionHandler(const ConfigServer* srv, int client_fd);
+    virtual ~ConnectionHandler();
 
     virtual int      fd() const;
     virtual uint32_t interests() const;
@@ -25,8 +25,8 @@ private:
     std::time_t _last_activity;
     long        _timeout;
 
-    ConnHandler(const ConnHandler&);
-    ConnHandler& operator=(const ConnHandler&);
+    ConnectionHandler(const ConnectionHandler&);
+    ConnectionHandler& operator=(const ConnectionHandler&);
 };
 
 #endif

--- a/include/HttpMessage.hpp
+++ b/include/HttpMessage.hpp
@@ -1,24 +1,24 @@
-#ifndef HTTP_MESSAGE_HPP
-#define HTTP_MESSAGE_HPP
+#ifndef HTTPMESSAGE_HPP
+#define HTTPMESSAGE_HPP
 
 #include <map>
 #include <string>
 
-class HTTP_Message {
+class HttpMessage {
 public:
     // What the header getter will return, this makes it easier to iterate over duplicate headers
-    typedef std::multimap<std::string, std::string>::const_iterator header_iterator;
+    typedef std::multimap<std::string, std::string>::const_iterator HeaderIterator;
 
-    HTTP_Message();
-    HTTP_Message(const HTTP_Message&);
-    const HTTP_Message& operator=(const HTTP_Message&);
-    ~HTTP_Message();
+    HttpMessage();
+    HttpMessage(const HttpMessage&);
+    const HttpMessage& operator=(const HttpMessage&);
+    ~HttpMessage();
 
     int                major_version() const;
     int                minor_version() const;
-    header_iterator    header(const std::string&) const;
-    header_iterator    headers_end() const;
-    header_iterator    headers_begin() const;
+    HeaderIterator     header(const std::string&) const;
+    HeaderIterator     headers_end() const;
+    HeaderIterator     headers_begin() const;
     bool               has_header(const std::string&) const;
     const std::string& body() const;
 

--- a/include/Listener.hpp
+++ b/include/Listener.hpp
@@ -8,7 +8,7 @@
 
 class Listener : public IHandler {
 public:
-    Listener(const Config_Server* srv, int listen_fd);
+    Listener(const ConfigServer* srv, int listen_fd);
     virtual ~Listener();
 
     virtual int      fd() const;
@@ -16,8 +16,8 @@ public:
     virtual bool     handle_event(ConnectionManager& manager, uint32_t events);
 
 private:
-    const Config_Server* _srv;
-    int                  _fd;
+    const ConfigServer* _srv;
+    int                 _fd;
 
     Listener(const Listener&);
     Listener& operator=(const Listener&);

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -8,7 +8,7 @@
 #include "config.hpp"
 
 // TODO Move ParsingStatus to a parsing.hpp header once parsing is done
-enum ParsingStatus { EMPTY, REQUEST_LINE, HEADERS, BODY, PARSED };
+enum ParsingStatus { EMPTY, REQUEST_LINE, HEADERS, BODY, PARSED, ERROR };
 
 /**
  * @brief Represents a request issued by an active connection.

--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -4,39 +4,39 @@
 #include <cstddef>
 #include <string>
 
-#include "HTTP_Message.hpp"
+#include "HttpMessage.hpp"
 #include "config.hpp"
 
-// TODO Move Status_Parsing to a parsing.hpp header once parsing is done
-enum Status_Parsing { EMPTY, REQUEST_LINE, HEADERS, BODY, PARSED, ERROR };
+// TODO Move ParsingStatus to a parsing.hpp header once parsing is done
+enum ParsingStatus { EMPTY, REQUEST_LINE, HEADERS, BODY, PARSED };
 
 /**
  * @brief Represents a request issued by an active connection.
  */
-class Request : public HTTP_Message {
+class Request : public HttpMessage {
 public:
     Request();
-    Request(const Config_Location* const, HTTP_Method);
+    Request(const ConfigLocation* const, HttpMethod);
     ~Request();
 
-    HTTP_Method        method() const;
-    Status_Parsing     status() const;
+    HttpMethod         method() const;
+    ParsingStatus      status() const;
     const std::string& target() const;
     size_t             content_length() const;
     size_t             client_max_body_size() const;
     size_t             body_received() const;
-    HTTP_Code          error_status() const;
+    HttpCode           error_status() const;
 
     bool               is_body_spooled() const;
     const std::string& body_path() const;
 
-    void set_config(const Config_Location* const);
-    void set_method(HTTP_Method);
-    void set_status(Status_Parsing);
+    void set_config(const ConfigLocation* const);
+    void set_method(HttpMethod);
+    void set_status(ParsingStatus);
     void set_target(const std::string&);
     void set_content_length(size_t);
     void set_client_max_body_size(size_t);
-    void set_error_status(HTTP_Code);
+    void set_error_status(HttpCode);
 
     bool append_body_chunk(const char* data, size_t len);
 
@@ -49,15 +49,15 @@ private:
     bool write_all(int fd, const char* data, size_t len);
     void cleanup_temp_file();
 
-    const Config_Location* _config;
+    const ConfigLocation* _config;
 
-    std::string    _target;
-    size_t         _content_length;
-    size_t         _client_max_body_size;
-    size_t         _body_received;
-    HTTP_Method    _method;
-    Status_Parsing _status;
-    HTTP_Code      _error_status;
+    std::string   _target;
+    size_t        _content_length;
+    size_t        _client_max_body_size;
+    size_t        _body_received;
+    HttpMethod    _method;
+    ParsingStatus _status;
+    HttpCode      _error_status;
 
     // Large bodies, over 64Kb
     size_t      _spool_threshold;
@@ -66,6 +66,6 @@ private:
     std::string _body_path;
 };
 
-Status_Parsing parse(std::string& read_buffer, size_t& read_index, Request& request);
+ParsingStatus parse(std::string& read_buffer, size_t& read_index, Request& request);
 
 #endif

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -3,26 +3,26 @@
 
 #include <string>
 
-#include "HTTP_Message.hpp"
+#include "HttpMessage.hpp"
 #include "config.hpp"
 
-class Response : public HTTP_Message {
+class Response : public HttpMessage {
 public:
     Response();
     Response(const Response&);
     const Response& operator=(const Response&);
     ~Response();
 
-    HTTP_Code          code() const;
+    HttpCode           code() const;
     const std::string& response_string() const;
 
-    void set_code(HTTP_Code);
+    void set_code(HttpCode);
     void set_response_string(const std::string&);
 
     std::string serialize() const;
 
 private:
-    HTTP_Code   _code;
+    HttpCode    _code;
     std::string _response_string;
 };
 

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -15,44 +15,45 @@
 
 #include "file_manager.hpp"
 
-typedef unsigned int HTTP_Code;
+typedef unsigned int HttpCode;
+typedef std::string  FilePath;
 
-enum HTTP_Method { UNDEFINED, GET, POST, DELETE };
+enum HttpMethod { UNDEFINED, GET, POST, DELETE };
 
-typedef struct Config_Location {
-    Config_Location();
+typedef struct ConfigLocation {
+    ConfigLocation();
 
-    std::set<HTTP_Method>            allowed_methods;
-    bool                             autoindex;
-    std::map<std::string, File_Path> cgi;  // Bind an extension to an interpreter
-    File_Path                        index;
-    std::map<HTTP_Code, std::string> redirect;  // Redirect to a URL using a specific HTTP code
-    File_Path                        root;
-    File_Path                        upload_store;
-} Config_Location;
+    std::set<HttpMethod>            allowed_methods;
+    bool                            autoindex;
+    std::map<std::string, FilePath> cgi;  // Bind an extension to an interpreter
+    FilePath                        index;
+    std::map<HttpCode, std::string> redirect;  // Redirect to a URL using a specific HTTP code
+    FilePath                        root;
+    FilePath                        upload_store;
+} ConfigLocation;
 
-typedef struct Config_Server {
-    Config_Server();
+typedef struct ConfigServer {
+    ConfigServer();
 
-    size_t                                 client_max_body_size;
-    std::map<HTTP_Code, std::string>       error_page;  // Error code to URI
-    std::vector<struct sockaddr_in>        listen;
-    std::map<std::string, Config_Location> location;
-    size_t                                 timeout;
-} Config_Server;
+    size_t                                client_max_body_size;
+    std::map<HttpCode, std::string>       error_page;  // Error code to URI
+    std::vector<struct sockaddr_in>       listen;
+    std::map<std::string, ConfigLocation> location;
+    size_t                                timeout;
+} ConfigServer;
 
 typedef struct Config {
     Config();
 
     // An empty error_log path means everything is logged to stderr
-    File_Path                  error_log;
-    std::vector<Config_Server> server;
+    FilePath                  error_log;
+    std::vector<ConfigServer> server;
 } Config;
 
-typedef std::vector<Config_Server>::const_iterator             ServerIter;
-typedef std::vector<struct sockaddr_in>::const_iterator        ListenIter;
-typedef std::map<HTTP_Code, std::string>::const_iterator       ErrorPageIter;
-typedef std::map<std::string, Config_Location>::const_iterator LocationIter;
-typedef std::map<std::string, File_Path>::const_iterator       CgiIter;
+typedef std::vector<ConfigServer>::const_iterator             ServerIterator;
+typedef std::vector<struct sockaddr_in>::const_iterator       ListenIterator;
+typedef std::map<HttpCode, std::string>::const_iterator       ErrorPageIterator;
+typedef std::map<std::string, ConfigLocation>::const_iterator LocationIterator;
+typedef std::map<std::string, FilePath>::const_iterator       CgiIterator;
 
 #endif

--- a/include/config_lexer.hpp
+++ b/include/config_lexer.hpp
@@ -1,5 +1,5 @@
-#ifndef CONFIGLEXER_HPP
-#define CONFIGLEXER_HPP
+#ifndef CONFIG_LEXER_HPP
+#define CONFIG_LEXER_HPP
 
 #include <fstream>
 #include <string>
@@ -12,7 +12,7 @@ struct Token {
     std::string    word;
 };
 
-typedef std::vector<Token>::const_iterator token_iterator;
+typedef std::vector<Token>::const_iterator TokenIterator;
 
 std::vector<Token> lex_config(std::ifstream& file_stream);
 

--- a/include/signal_state.hpp
+++ b/include/signal_state.hpp
@@ -1,5 +1,5 @@
-#ifndef SIGNALSTATE_HPP
-#define SIGNALSTATE_HPP
+#ifndef SIGNAL_STATE_HPP
+#define SIGNAL_STATE_HPP
 
 #include <csignal>
 

--- a/include/socket_utils.hpp
+++ b/include/socket_utils.hpp
@@ -4,6 +4,6 @@
 #include "config.hpp"
 
 int              set_nonblocking(int fd);
-std::vector<int> make_listen_sockets(const Config_Server&);
+std::vector<int> make_listen_sockets(const ConfigServer&);
 
 #endif

--- a/src/ConfigParser/config_lexer.cpp
+++ b/src/ConfigParser/config_lexer.cpp
@@ -1,4 +1,5 @@
-#include <ConfigLexer.hpp>
+#include "config_lexer.hpp"
+
 #include <cctype>
 #include <fstream>
 #include <ios>

--- a/src/ConfigParser/config_parser.cpp
+++ b/src/ConfigParser/config_parser.cpp
@@ -334,7 +334,7 @@ ConfigLocation parse_location(TokenIterator* t, TokenIterator end) {
                     throw ParserError(tokens[0],
                                       "Wrong number of tokens in allowed_methods directive");
                 for (size_t i = 1; i < tokens.size() - 1; ++i) {
-                    HTTP_Method m;
+                    HttpMethod m;
                     if (tokens[i].word == "GET") {
                         m = GET;
                     } else if (tokens[i].word == "POST") {

--- a/src/ConfigParser/config_parser.cpp
+++ b/src/ConfigParser/config_parser.cpp
@@ -1,5 +1,3 @@
-#include "ConfigParser.hpp"
-
 #include <netdb.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -18,8 +16,9 @@
 #include <utility>
 #include <vector>
 
-#include "ConfigLexer.hpp"
+#include "ConfigParser.hpp"
 #include "config.hpp"
+#include "config_lexer.hpp"
 #include "file_manager.hpp"
 
 // We construct the error string in the constructors to be able to return a pointer to it later
@@ -57,11 +56,11 @@ const char* ParserError::what() const throw() {
  * @return 0 if no dupes were found, 1 if so.
  */
 static int check_listen(const Config& config) {
-    const std::vector<Config_Server>&       servers = config.server;
+    const std::vector<ConfigServer>&        servers = config.server;
     std::multimap<unsigned short, uint32_t> listens;
 
-    for (ServerIter s = servers.begin(); s != servers.end(); ++s) {
-        for (ListenIter l = s->listen.begin(); l != s->listen.end(); ++l) {
+    for (ServerIterator s = servers.begin(); s != servers.end(); ++s) {
+        for (ListenIterator l = s->listen.begin(); l != s->listen.end(); ++l) {
             const unsigned short port = l->sin_port;
             const uint32_t       address = l->sin_addr.s_addr;
 
@@ -94,22 +93,23 @@ static void check_config(const Config& config) {
 
     if (check_listen(config) != 0) throw ParserError("Duplicate listen directive");
 
-    for (ServerIter s = config.server.begin(); s != config.server.end(); ++s) {
-        for (ErrorPageIter e = s->error_page.begin(); e != s->error_page.end(); ++e) {
+    for (ServerIterator s = config.server.begin(); s != config.server.end(); ++s) {
+        for (ErrorPageIterator e = s->error_page.begin(); e != s->error_page.end(); ++e) {
             if (e->first <= 400 || e->first >= 599)
                 throw ParserError("Invalid error_page directive (wrong HTTP code)");
         }
 
-        for (LocationIter l = s->location.begin(); l != s->location.end(); ++l) {
+        for (LocationIterator l = s->location.begin(); l != s->location.end(); ++l) {
             if (l->second.allowed_methods.empty())
                 std::cerr << "[PARSING] - Location " << l->first << " is missing an allowed method."
                           << std::endl;
-            for (CgiIter j = l->second.cgi.begin(); j != l->second.cgi.end(); ++j) {
+            for (CgiIterator j = l->second.cgi.begin(); j != l->second.cgi.end(); ++j) {
                 if (is_regular_file(j->second) == false) throw ParserError("Invalid cgi directive");
             }
             if (l->second.index.empty() == false && is_regular_file(l->second.index) == false)
                 throw ParserError("Invalid index directive");
-            for (ErrorPageIter r = l->second.redirect.begin(); r != l->second.redirect.end(); ++r) {
+            for (ErrorPageIterator r = l->second.redirect.begin(); r != l->second.redirect.end();
+                 ++r) {
                 // Redirection have to use a 3XX code
                 if (r->first < 300 || r->first > 399)
                     throw ParserError("Invalid redirect directive");
@@ -135,13 +135,13 @@ Config parse_file(std::ifstream& file) {
     if (config.server.empty()) {
         throw ParserError("Missing server directive");
     }
-    for (ServerIter s = config.server.begin(); s != config.server.end(); ++s) {
+    for (ServerIterator s = config.server.begin(); s != config.server.end(); ++s) {
         if (s->listen.empty()) {
             throw ParserError("Missing listen directive in server context");
         } else if (s->location.empty()) {
             throw ParserError("Missing location directive in server context");
         } else {
-            for (LocationIter i = s->location.begin(); i != s->location.end(); ++i) {
+            for (LocationIterator i = s->location.begin(); i != s->location.end(); ++i) {
                 if (i->second.root.empty() && i->second.redirect.empty()) {
                     throw ParserError("Missing root directive in location context");
                 }
@@ -170,7 +170,7 @@ static bool check_string(const std::string& string, const std::string& allowed_s
  * @brief Consume all tokens until the first one that is a special character.
  * For reference, special characters are braces and semicolons.
  */
-static std::vector<Token> parse_line(token_iterator* t) {
+static std::vector<Token> parse_line(TokenIterator* t) {
     std::vector<Token> tokens;
 
     while ((*t)->type == WORD) {
@@ -193,7 +193,7 @@ static std::vector<Token> parse_line(token_iterator* t) {
 /**
  * @brief Process a vector of tokens to create a Config struct out of them.
  */
-Config parse_config(token_iterator t, token_iterator end) {
+Config parse_config(TokenIterator t, TokenIterator end) {
     Config config;
 
     while (t != end) {
@@ -221,8 +221,8 @@ Config parse_config(token_iterator t, token_iterator end) {
     return config;
 }
 
-Config_Server parse_server(token_iterator* t, token_iterator end) {
-    Config_Server config;
+ConfigServer parse_server(TokenIterator* t, TokenIterator end) {
+    ConfigServer config;
 
     while (*t != end) {
         std::vector<Token> tokens = parse_line(t);
@@ -263,13 +263,13 @@ Config_Server parse_server(token_iterator* t, token_iterator end) {
             } else if (directive == "error_page") {
                 if (tokens.size() < 4)
                     throw ParserError(tokens[0], "Wrong number of tokens in error_page directive");
-                File_Path path = standardize_path(tokens[tokens.size() - 2].word);
+                FilePath path = standardize_path(tokens[tokens.size() - 2].word);
                 for (size_t i = 1; i < tokens.size() - 2; ++i) {
                     if (check_string(tokens[i].word, "1234567890") == false)
                         throw ParserError(tokens[1], "Wrong error_page HTTP code syntax");
-                    HTTP_Code code = static_cast<unsigned int>(std::atol(tokens[i].word.c_str()));
+                    HttpCode code = static_cast<unsigned int>(std::atol(tokens[i].word.c_str()));
 
-                    config.error_page.insert(std::pair<HTTP_Code, File_Path>(code, path));
+                    config.error_page.insert(std::pair<HttpCode, FilePath>(code, path));
                 }
             } else if (directive == "listen") {
                 if (tokens.size() != 4)
@@ -299,7 +299,7 @@ Config_Server parse_server(token_iterator* t, token_iterator end) {
             } else if (directive == "location") {
                 if (tokens.size() != 3)
                     throw ParserError(tokens[0], "Wrong number of tokens in location directive");
-                config.location.insert(std::pair<std::string, Config_Location>(
+                config.location.insert(std::pair<std::string, ConfigLocation>(
                     tokens[1].word, parse_location((t), end)));
             } else if (directive == "timeout") {
                 if (tokens.size() != 3)
@@ -320,8 +320,8 @@ Config_Server parse_server(token_iterator* t, token_iterator end) {
     return config;
 }
 
-Config_Location parse_location(token_iterator* t, token_iterator end) {
-    Config_Location config;
+ConfigLocation parse_location(TokenIterator* t, TokenIterator end) {
+    ConfigLocation config;
 
     while (*t != end) {
         std::vector<Token> tokens = parse_line(t);
@@ -361,7 +361,7 @@ Config_Location parse_location(token_iterator* t, token_iterator end) {
             } else if (directive == "cgi") {
                 if (tokens.size() != 4)
                     throw ParserError(tokens[0], "Wrong number of tokens in cgi directive");
-                config.cgi.insert(std::pair<std::string, File_Path>(
+                config.cgi.insert(std::pair<std::string, FilePath>(
                     tokens[1].word, standardize_path(tokens[2].word)));
             } else if (directive == "index") {
                 if (tokens.size() < 3)
@@ -372,8 +372,8 @@ Config_Location parse_location(token_iterator* t, token_iterator end) {
                     throw ParserError(tokens[0], "Wrong number of tokens in redirect directive");
                 if (check_string(tokens[1].word, "1234567890") == false)
                     throw ParserError(tokens[1], "Wrong redirection code syntax");
-                HTTP_Code code = static_cast<HTTP_Code>(std::atol(tokens[1].word.c_str()));
-                config.redirect.insert(std::pair<HTTP_Code, std::string>(code, tokens[2].word));
+                HttpCode code = static_cast<HttpCode>(std::atol(tokens[1].word.c_str()));
+                config.redirect.insert(std::pair<HttpCode, std::string>(code, tokens[2].word));
             } else if (directive == "root") {
                 if (tokens.size() != 3)
                     throw ParserError(tokens[0], "Wrong number of tokens in root directive");

--- a/src/ConnectionManager/Connection.cpp
+++ b/src/ConnectionManager/Connection.cpp
@@ -12,7 +12,7 @@
 #include "Response.hpp"
 #include "config.hpp"
 
-Connection::Connection(const Config_Server* const config, int socket)
+Connection::Connection(const ConfigServer* const config, int socket)
     : _config(config),
       _request(),
       _response(),
@@ -21,7 +21,7 @@ Connection::Connection(const Config_Server* const config, int socket)
       _read_index(0),
       _write_buffer(),
       _write_index(0) {
-    assert(config && "Config_Server pointer");
+    assert(config && "ConfigServer pointer");
     assert(socket > 2 && "Valid Socket Number");
     _request.set_client_max_body_size(_config->client_max_body_size);
 }
@@ -119,8 +119,8 @@ bool Connection::has_pending_write() const {
     return _write_index < _write_buffer.size();
 }
 
-void Connection::set_config(const Config_Server* const config) {
-    assert(config && "Config_Server pointer");
+void Connection::set_config(const ConfigServer* const config) {
+    assert(config && "ConfigServer pointer");
 
     _config = config;
 }

--- a/src/ConnectionManager/Connection.cpp
+++ b/src/ConnectionManager/Connection.cpp
@@ -105,8 +105,8 @@ void Connection::compact_read_buffer() {
     }
 }
 
-Status_Parsing Connection::parse_request() {
-    Status_Parsing status = parse(_read_buffer, _read_index, _request);
+ParsingStatus Connection::parse_request() {
+    ParsingStatus status = parse(_read_buffer, _read_index, _request);
     compact_read_buffer();
     return status;
 }

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -1,4 +1,4 @@
-#include "ConnHandler.hpp"
+#include "ConnectionHandler.hpp"
 
 #include <sys/epoll.h>
 
@@ -76,19 +76,19 @@ static std::string hello_response() {
            body;
 }
 
-ConnHandler::ConnHandler(const Config_Server* srv, int client_fd)
+ConnectionHandler::ConnectionHandler(const ConfigServer* srv, int client_fd)
     : _fd(client_fd),
       _conn(srv, client_fd),
       _last_activity(std::time(NULL)),
       _timeout(static_cast<long>(srv->timeout)) {}
 
-ConnHandler::~ConnHandler() {}
+ConnectionHandler::~ConnectionHandler() {}
 
-int ConnHandler::fd() const {
+int ConnectionHandler::fd() const {
     return _fd;
 }
 
-uint32_t ConnHandler::interests() const {
+uint32_t ConnectionHandler::interests() const {
     // EPOLLOUT only when something must be sent back, else stay ready to listen
     if (_conn.has_pending_write())
         return EPOLLIN | EPOLLOUT;
@@ -96,12 +96,12 @@ uint32_t ConnHandler::interests() const {
         return EPOLLIN;
 }
 
-bool ConnHandler::is_timed_out() const {
+bool ConnectionHandler::is_timed_out() const {
     std::cout << _timeout << std::endl;
     return (std::time(NULL) - _last_activity) > _timeout;
 }
 
-bool ConnHandler::handle_event(ConnectionManager& manager, uint32_t events) {
+bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events) {
     (void)manager;
 
     if (events & (EPOLLERR | EPOLLHUP)) {

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -10,7 +10,7 @@
 #include "Request.hpp"
 #include "config.hpp"
 
-static std::string error_response(HTTP_Code code) {
+static std::string error_response(HttpCode code) {
     std::string reason;
 
     switch (code) {
@@ -116,9 +116,9 @@ bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events
         if (n < 0) return false;
         if (n == 0) return false;  // temp to avoid infinite calls when closed by client
 
-        Status_Parsing r = _conn.parse_request();
+        ParsingStatus r = _conn.parse_request();
         if (r == ERROR) {
-            HTTP_Code code = _conn.request().error_status();
+            HttpCode code = _conn.request().error_status();
             _conn.queue_write(error_response(code));
             _conn.send_data();
             return false;
@@ -137,7 +137,7 @@ bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events
                 std::cout << "Body size (RAM): " << req.body().size() << "\n";
             }
             std::cout << "----- [HEADERS] -----\n";
-            for (HTTP_Message::header_iterator it = req.headers_begin(); it != req.headers_end();
+            for (HttpMessage::HeaderIterator it = req.headers_begin(); it != req.headers_end();
                  ++it) {
                 std::cout << it->first << ": " << it->second << "\n";
             }

--- a/src/ConnectionManager/ConnectionManager.cpp
+++ b/src/ConnectionManager/ConnectionManager.cpp
@@ -8,7 +8,7 @@
 #include <cstring>
 #include <iostream>
 
-#include "signalstate.hpp"
+#include "signal_state.hpp"
 
 ConnectionManager::ConnectionManager() : _epfd(epoll_create(1)) {
     if (_epfd < 0)

--- a/src/ConnectionManager/HttpMessage.cpp
+++ b/src/ConnectionManager/HttpMessage.cpp
@@ -55,14 +55,14 @@ void HttpMessage::append_body(const std::string& data) {
     _body.append(data);
 }
 
-bool HTTP_Message::has_header(const std::string& header_name) const {
+bool HttpMessage::has_header(const std::string& header_name) const {
     return _headers.find(header_name) != _headers.end();
 }
 
-HTTP_Message::header_iterator HTTP_Message::headers_begin() const {
+HttpMessage::HeaderIterator HttpMessage::headers_begin() const {
     return _headers.begin();
 }
 
-HTTP_Message::header_iterator HTTP_Message::headers_end() const {
+HttpMessage::HeaderIterator HttpMessage::headers_end() const {
     return _headers.end();
 }

--- a/src/ConnectionManager/HttpMessage.cpp
+++ b/src/ConnectionManager/HttpMessage.cpp
@@ -1,14 +1,14 @@
-#include "HTTP_Message.hpp"
+#include "HttpMessage.hpp"
 
-HTTP_Message::HTTP_Message() : _major_version(0), _minor_version(0), _headers(), _body() {}
+HttpMessage::HttpMessage() : _major_version(0), _minor_version(0), _headers(), _body() {}
 
-HTTP_Message::HTTP_Message(const HTTP_Message& other)
+HttpMessage::HttpMessage(const HttpMessage& other)
     : _major_version(other._major_version),
       _minor_version(other._minor_version),
       _headers(other._headers),
       _body(other._body) {}
 
-const HTTP_Message& HTTP_Message::operator=(const HTTP_Message& other) {
+const HttpMessage& HttpMessage::operator=(const HttpMessage& other) {
     if (this == &other) {
         return *this;
     }
@@ -21,36 +21,37 @@ const HTTP_Message& HTTP_Message::operator=(const HTTP_Message& other) {
     return *this;
 }
 
-HTTP_Message::~HTTP_Message() {}
+HttpMessage::~HttpMessage() {}
 
-const std::string& HTTP_Message::body() const {
+const std::string& HttpMessage::body() const {
     return _body;
 }
 
-int HTTP_Message::major_version() const {
+int HttpMessage::major_version() const {
     return _major_version;
 }
 
-int HTTP_Message::minor_version() const {
+int HttpMessage::minor_version() const {
     return _minor_version;
 }
+
 /**
  * @brief Return an iterator to the first header with the name `header_name`.
  */
-HTTP_Message::header_iterator HTTP_Message::header(const std::string& header_name) const {
+HttpMessage::HeaderIterator HttpMessage::header(const std::string& header_name) const {
     return _headers.lower_bound(header_name);
 }
 
-void HTTP_Message::set_version(int major_version, int minor_version) {
+void HttpMessage::set_version(int major_version, int minor_version) {
     _major_version = major_version;
     _minor_version = minor_version;
 }
 
-void HTTP_Message::set_header(const std::string& name, const std::string& value) {
+void HttpMessage::set_header(const std::string& name, const std::string& value) {
     _headers.insert(std::pair<std::string, std::string>(name, value));
 }
 
-void HTTP_Message::append_body(const std::string& data) {
+void HttpMessage::append_body(const std::string& data) {
     _body.append(data);
 }
 

--- a/src/ConnectionManager/Listener.cpp
+++ b/src/ConnectionManager/Listener.cpp
@@ -6,11 +6,11 @@
 
 #include <iostream>
 
-#include "ConnHandler.hpp"
+#include "ConnectionHandler.hpp"
 #include "ConnectionManager.hpp"
 #include "socket_utils.hpp"
 
-Listener::Listener(const Config_Server* srv, int listen_fd) : _srv(srv), _fd(listen_fd) {}
+Listener::Listener(const ConfigServer* srv, int listen_fd) : _srv(srv), _fd(listen_fd) {}
 Listener::~Listener() {}
 
 int Listener::fd() const {
@@ -40,7 +40,7 @@ bool Listener::handle_event(ConnectionManager& manager, uint32_t events) {
 
         std::cout << "[LISTENER] New client accepted fd=" << client_fd << std::endl;
 
-        manager.add(new ConnHandler(_srv, client_fd));
+        manager.add(new ConnectionHandler(_srv, client_fd));
     }
     return true;  // keeps listener
 }

--- a/src/ConnectionManager/Request.cpp
+++ b/src/ConnectionManager/Request.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "HttpMessage.hpp"
 #include "config.hpp"
 
 #ifndef REQUEST_BODY_SPOOL_THRESHOLD
@@ -32,7 +33,7 @@ Request::Request()
       _body_fd(-1),
       _body_path("") {}
 
-Request::Request(const Config_Location* const config, HTTP_Method method)
+Request::Request(const ConfigLocation* const config, HttpMethod method)
     : _config(config),
       _target(""),
       _content_length(0),
@@ -56,7 +57,7 @@ HTTP_Method Request::method() const {
     return _method;
 }
 
-Status_Parsing Request::status() const {
+ParsingStatus Request::status() const {
     return _status;
 }
 
@@ -71,6 +72,7 @@ size_t Request::content_length() const {
 size_t Request::client_max_body_size() const {
     return _client_max_body_size;
 }
+
 void Request::set_client_max_body_size(size_t client_max_body_size) {
     _client_max_body_size = client_max_body_size;
 }
@@ -91,17 +93,17 @@ const std::string& Request::body_path() const {
     return _body_path;
 }
 
-void Request::set_config(const Config_Location* const config) {
+void Request::set_config(const ConfigLocation* const config) {
     assert(config && "Config_Server pointer");
 
     _config = config;
 }
 
-void Request::set_method(HTTP_Method method) {
+void Request::set_method(HttpMethod method) {
     _method = method;
 }
 
-void Request::set_status(Status_Parsing status) {
+void Request::set_status(ParsingStatus status) {
     if (status == ERROR) {
         _status = status;
         return;

--- a/src/ConnectionManager/Request.cpp
+++ b/src/ConnectionManager/Request.cpp
@@ -53,7 +53,7 @@ Request::~Request() {
     cleanup_temp_file();
 }
 
-HTTP_Method Request::method() const {
+HttpMethod Request::method() const {
     return _method;
 }
 
@@ -81,7 +81,7 @@ size_t Request::body_received() const {
     return _body_received;
 }
 
-HTTP_Code Request::error_status() const {
+HttpCode Request::error_status() const {
     return _error_status;
 }
 
@@ -120,7 +120,7 @@ void Request::set_content_length(size_t content_length) {
     _content_length = content_length;
 }
 
-void Request::set_error_status(HTTP_Code code) {
+void Request::set_error_status(HttpCode code) {
     _error_status = code;
 }
 

--- a/src/ConnectionManager/Response.cpp
+++ b/src/ConnectionManager/Response.cpp
@@ -4,13 +4,13 @@
 #include <cstdlib>
 #include <string>
 
-#include "HTTP_Message.hpp"
+#include "HttpMessage.hpp"
 #include "config.hpp"
 
 Response::Response() : _code(0), _response_string() {}
 
 Response::Response(const Response& other)
-    : HTTP_Message(other), _code(other._code), _response_string(other._response_string) {}
+    : HttpMessage(other), _code(other._code), _response_string(other._response_string) {}
 
 const Response& Response::operator=(const Response& other) {
     if (this == &other) return *this;
@@ -23,7 +23,7 @@ const Response& Response::operator=(const Response& other) {
 
 Response::~Response() {}
 
-HTTP_Code Response::code() const {
+HttpCode Response::code() const {
     return _code;
 }
 
@@ -31,7 +31,7 @@ const std::string& Response::response_string() const {
     return _response_string;
 }
 
-void Response::set_code(HTTP_Code code) {
+void Response::set_code(HttpCode code) {
     assert(code >= 100 && code <= 599 && "Correct HTTP Code");
     _code = code;
 }

--- a/src/ConnectionManager/request_parser.cpp
+++ b/src/ConnectionManager/request_parser.cpp
@@ -57,8 +57,8 @@ static bool parse_content_length_value(const std::string& value, size_t& out) {
     return true;
 }
 
-static Status_Parsing parse_request_line(const std::string& read_buffer, size_t& read_index,
-                                         Request& request) {
+static ParsingStatus parse_request_line(const std::string& read_buffer, size_t& read_index,
+                                        Request& request) {
     if (request.status() != EMPTY) return request.status();
 
     std::string::size_type line_end = read_buffer.find("\r\n", read_index);
@@ -106,8 +106,8 @@ static Status_Parsing parse_request_line(const std::string& read_buffer, size_t&
     return request.status();
 }
 
-static Status_Parsing parse_headers(const std::string& read_buffer, size_t& read_index,
-                                    Request& request) {
+static ParsingStatus parse_headers(const std::string& read_buffer, size_t& read_index,
+                                   Request& request) {
     if (request.status() != REQUEST_LINE) return request.status();
 
     while (true) {
@@ -123,7 +123,7 @@ static Status_Parsing parse_headers(const std::string& read_buffer, size_t& read
             size_t content_length_count = 0;
             size_t content_length_value = 0;
 
-            for (HTTP_Message::header_iterator it = request.headers_begin();
+            for (HttpMessage::HeaderIterator it = request.headers_begin();
                  it != request.headers_end(); ++it) {
                 if (it->first == "Content-Length") {
                     ++content_length_count;
@@ -181,8 +181,8 @@ static Status_Parsing parse_headers(const std::string& read_buffer, size_t& read
     }
 }
 
-static Status_Parsing parse_body(const std::string& read_buffer, size_t& read_index,
-                                 Request& request) {
+static ParsingStatus parse_body(const std::string& read_buffer, size_t& read_index,
+                                Request& request) {
     if (request.status() != BODY) return request.status();
 
     size_t expected = request.content_length();
@@ -213,7 +213,7 @@ static Status_Parsing parse_body(const std::string& read_buffer, size_t& read_in
     return request.status();
 }
 
-Status_Parsing parse(std::string& read_buffer, size_t& read_index, Request& request) {
+ParsingStatus parse(std::string& read_buffer, size_t& read_index, Request& request) {
     if (request.status() == EMPTY) parse_request_line(read_buffer, read_index, request);
 
     if (request.status() == REQUEST_LINE) parse_headers(read_buffer, read_index, request);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -6,10 +6,10 @@
 // This would mean that you can't technically interact with the location, since no allowed
 // methods have been defined. We won't set GET as default, since maybe that's not what the user
 // wants, who knows.
-Config_Location::Config_Location()
+ConfigLocation::ConfigLocation()
     : allowed_methods(), autoindex(false), cgi(), index(), redirect(), root(), upload_store() {}
 
-Config_Server::Config_Server()
+ConfigServer::ConfigServer()
     : client_max_body_size(0), error_page(), listen(), location(), timeout(0) {}
 
 Config::Config() : error_log(), server() {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,8 +45,8 @@ int main(int argc, char** argv) {
     config_file.close();
 
     ConnectionManager manager;
-    for (ServerIter s = config.server.begin(); s != config.server.end(); ++s) {
-        const Config_Server& server_config = *s;
+    for (ServerIterator s = config.server.begin(); s != config.server.end(); ++s) {
+        const ConfigServer&  server_config = *s;
         std::vector<int>     listen_fds;
         try {
             listen_fds = make_listen_sockets(server_config);

--- a/src/socket_utils.cpp
+++ b/src/socket_utils.cpp
@@ -24,10 +24,10 @@ int set_nonblocking(int fd) {
 /**
  * @brief Creates a vector of listening sockets based on all listen directives in a server context.
  */
-std::vector<int> make_listen_sockets(const Config_Server& config) {
+std::vector<int> make_listen_sockets(const ConfigServer& config) {
     std::vector<int> fds;
 
-    for (ListenIter l = config.listen.begin(); l != config.listen.end(); ++l) {
+    for (ListenIterator l = config.listen.begin(); l != config.listen.end(); ++l) {
         const struct sockaddr_in& address = *l;
         int                       fd = socket(AF_INET, SOCK_STREAM, 0);
         if (fd < 0) throw;


### PR DESCRIPTION
This PR makes the main start to follow the new nomenclature for the project, as defined below.
# Project Nomenclature
- All types (structs, classes, typedefs...) should be in PascalCase
- Variables stick to camel_case
- Files containing only functions are camel_case, while files containing class implementation or interfaces are PascalCase
- Abbreviations (especially in filenames) should be reduced to a minimum, unless it is really idiomatic this way (like i for iterator in a loop)
