### PR TITLE
Feat/logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ RMFLAGS		=	-f
 SRCDIR		=	src
 CFILES		=	$(SRCDIR)/main.cpp \
 				$(SRCDIR)/config.cpp \
-				$(SRCDIR)/logger.cpp \
+				$(SRCDIR)/Logger.cpp \
 				$(SRCDIR)/ConfigParser/config_lexer.cpp \
 				$(SRCDIR)/ConfigParser/config_parser.cpp \
 				$(SRCDIR)/ConnectionManager/Connection.cpp \

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ RMFLAGS		=	-f
 SRCDIR		=	src
 CFILES		=	$(SRCDIR)/main.cpp \
 				$(SRCDIR)/config.cpp \
+				$(SRCDIR)/logger.cpp \
 				$(SRCDIR)/ConfigParser/config_lexer.cpp \
 				$(SRCDIR)/ConfigParser/config_parser.cpp \
 				$(SRCDIR)/ConnectionManager/Connection.cpp \

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -3,7 +3,7 @@
 
 #include <sstream>
 
-enum LogLevel { DEBUG_LOG, GENERAL_LOG, ERROR_LOG };
+enum LogLevel { LOG_DEBUG, LOG_GENERAL, LOG_ERROR };
 
 /**
  * Usage: Logger(DEBUG_LOG) << "string " << num << " string"

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -24,4 +24,6 @@ private:
     std::ostringstream _oss;
 };
 
+void logger_init();
+
 #endif

--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -1,0 +1,27 @@
+#ifndef LOGGER_HPP
+#define LOGGER_HPP
+
+#include <sstream>
+
+enum LogLevel { DEBUG_LOG, GENERAL_LOG, ERROR_LOG };
+
+/**
+ * Usage: Logger(DEBUG_LOG) << "string " << num << " string"
+ */
+class Logger {
+public:
+    Logger(LogLevel level);
+    ~Logger();
+
+    template <typename T>
+    Logger& operator<<(const T& value) {
+        _oss << value;
+        return *this;
+    }
+
+private:
+    LogLevel           _level;
+    std::ostringstream _oss;
+};
+
+#endif

--- a/src/ConfigParser/config_parser.cpp
+++ b/src/ConfigParser/config_parser.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "ConfigParser.hpp"
+#include "Logger.hpp"
 #include "config.hpp"
 #include "config_lexer.hpp"
 #include "file_manager.hpp"
@@ -101,8 +102,8 @@ static void check_config(const Config& config) {
 
         for (LocationIterator l = s->location.begin(); l != s->location.end(); ++l) {
             if (l->second.allowed_methods.empty())
-                std::cerr << "[PARSING] - Location " << l->first << " is missing an allowed method."
-                          << std::endl;
+                Logger(LOG_ERROR) << "[PARSING] - Location " << l->first
+                                  << " is missing an allowed method.";
             for (CgiIterator j = l->second.cgi.begin(); j != l->second.cgi.end(); ++j) {
                 if (is_regular_file(j->second) == false) throw ParserError("Invalid cgi directive");
             }

--- a/src/ConnectionManager/Connection.cpp
+++ b/src/ConnectionManager/Connection.cpp
@@ -6,8 +6,8 @@
 #include <cassert>
 #include <cerrno>
 #include <cstring>
-#include <iostream>
 
+#include "Logger.hpp"
 #include "Request.hpp"
 #include "Response.hpp"
 #include "config.hpp"
@@ -48,7 +48,7 @@ ssize_t Connection::send_data() {
     if (n == 0)
         return 0;
     else if (n < 0) {
-        std::cerr << "[Connection::send_data] send: " << strerror(errno) << std::endl;
+        Logger(LOG_ERROR) << "[Connection::send_data] send: " << strerror(errno);
         return -1;
     }
 
@@ -74,11 +74,11 @@ ssize_t Connection::receive_data() {
             total += n;
         } else if (n == 0) {
             // closing client
-            std::cout << "[CONN " << _socket << "] client closed recv0" << std::endl;
+            Logger(LOG_GENERAL) << "[CONN " << _socket << "] client closed recv0";
             return 0;
         } else {
             if (errno == EAGAIN || errno == EWOULDBLOCK) break;  // nothing to read
-            std::cerr << "[Connection::receive_data] recv: " << std::strerror(errno) << std::endl;
+            Logger(LOG_ERROR) << "[Connection::receive_data] recv: " << std::strerror(errno);
             return -1;
         }
     }

--- a/src/ConnectionManager/Connection.cpp
+++ b/src/ConnectionManager/Connection.cpp
@@ -45,7 +45,6 @@ ssize_t Connection::send_data() {
     size_t chunk = remaining > SEND_SIZE ? SEND_SIZE : remaining;
 
     ssize_t n = send(_socket, _write_buffer.data() + _write_index, chunk, 0);
-    std::cout << "[CONN " << _socket << "] sent " << n << " bytes" << std::endl;
     if (n == 0)
         return 0;
     else if (n < 0) {
@@ -61,7 +60,6 @@ ssize_t Connection::send_data() {
         _write_buffer.clear();
         _write_index = 0;
     }
-    std::cout << "[CONN " << _socket << "] write complete" << std::endl;
     return n;
 }
 
@@ -84,8 +82,8 @@ ssize_t Connection::receive_data() {
             return -1;
         }
     }
-    if (total > 0)
-        std::cout << "[CONN " << _socket << "] received " << total << " bytes" << std::endl;
+    // if (total > 0)
+    //     std::cout << "[CONN " << _socket << "] received " << total << " bytes" << std::endl;
 
     return total;
 }

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -96,7 +96,7 @@ static void log_request(const Request& request) {
          ++it) {
         std::cout << it->first << ": " << it->second << "\n";
     }
-    std::cout << "----- [REQ END] -----" << "\n\n\n";
+    std::cout << "----- [REQ END] -----" << "\n";
 }
 
 ConnectionHandler::ConnectionHandler(const ConfigServer* srv, int client_fd)
@@ -142,7 +142,6 @@ bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events
     }
 
     if (events & EPOLLIN) {
-        std::cout << "[CONN " << _fd << "] EPOLLIN" << std::endl;
         ssize_t n = _conn.receive_data();
 
         if (n < 0) return false;

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include "ConnectionManager.hpp"
+#include "Logger.hpp"
 #include "Request.hpp"
 #include "config.hpp"
 
@@ -80,23 +81,23 @@ static std::string hello_response() {
  * @brief Prints a request's status, as well as its body information and headers.
  */
 static void log_request(const Request& request) {
-    std::cout << "----- [REQUEST] -----\n";
-    std::cout << "Request Status:" << request.status() << "\n";
-    std::cout << "Method: " << request.method() << "\n";
-    std::cout << "Target: " << request.target() << "\n";
-    std::cout << "Body received: [" << request.body_received() << "]\n";
-    std::cout << "Is body spooled: [" << request.is_body_spooled() << "]\n";
+    Logger(LOG_DEBUG) << "----- [REQUEST] -----";
+    Logger(LOG_DEBUG) << "Request Status:" << request.status();
+    Logger(LOG_DEBUG) << "Method: " << request.method();
+    Logger(LOG_DEBUG) << "Target: " << request.target();
+    Logger(LOG_DEBUG) << "Body received: [" << request.body_received() << "]";
+    Logger(LOG_DEBUG) << "Is body spooled: [" << request.is_body_spooled() << "]";
     if (request.is_body_spooled()) {
-        std::cout << "Body path: " << request.body_path() << "\n";
+        Logger(LOG_DEBUG) << "Body path: " << request.body_path();
     } else {
-        std::cout << "Body size (RAM): " << request.body().size() << "\n";
+        Logger(LOG_DEBUG) << "Body size (RAM): " << request.body().size();
     }
-    std::cout << "----- [HEADERS] -----\n";
+    Logger(LOG_DEBUG) << "----- [HEADERS] -----";
     for (HttpMessage::HeaderIterator it = request.headers_begin(); it != request.headers_end();
          ++it) {
-        std::cout << it->first << ": " << it->second << "\n";
+        Logger(LOG_DEBUG) << it->first << ": " << it->second;
     }
-    std::cout << "----- [REQ END] -----" << "\n";
+    Logger(LOG_DEBUG) << "----- [REQ END] -----\n";
 }
 
 ConnectionHandler::ConnectionHandler(const ConfigServer* srv, int client_fd)
@@ -137,7 +138,7 @@ bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events
     (void)manager;
 
     if (events & (EPOLLERR | EPOLLHUP)) {
-        std::cerr << "[CONN " << _fd << "] Error: Wrong epoll event";
+        Logger(LOG_ERROR) << "[CONN " << _fd << "] Error: Wrong epoll event";
         return false;
     }
 

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -120,7 +120,6 @@ uint32_t ConnectionHandler::interests() const {
 }
 
 bool ConnectionHandler::is_timed_out() const {
-    std::cout << _timeout << std::endl;
     return (std::time(NULL) - _last_activity) > _timeout;
 }
 

--- a/src/ConnectionManager/ConnectionManager.cpp
+++ b/src/ConnectionManager/ConnectionManager.cpp
@@ -6,13 +6,12 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 
+#include "Logger.hpp"
 #include "signal_state.hpp"
 
 ConnectionManager::ConnectionManager() : _epfd(epoll_create(1)) {
-    if (_epfd < 0)
-        std::cerr << "[ConnectionManager] epoll_create: " << strerror(errno) << std::endl;
+    if (_epfd < 0) Logger(LOG_ERROR) << "[ConnectionManager] epoll_create: " << strerror(errno);
 }
 
 ConnectionManager::~ConnectionManager() {
@@ -21,7 +20,7 @@ ConnectionManager::~ConnectionManager() {
         IHandler* h = it->second;
 
         if (epoll_ctl(_epfd, EPOLL_CTL_DEL, fd, NULL) != 0)
-            std::cerr << "[~ConnectionManager] epoll_ctl: " << strerror(errno) << std::endl;
+            Logger(LOG_ERROR) << "[~ConnectionManager] epoll_ctl: " << strerror(errno);
         close(fd);
         delete h;
     }
@@ -38,7 +37,7 @@ int ConnectionManager::add(IHandler* h) {
 
     // Add fd to epoll
     if (epoll_ctl(_epfd, EPOLL_CTL_ADD, h->fd(), &ev) != 0) {
-        std::cerr << "[ConnectionManager::add] epoll_ctl: " << strerror(errno) << std::endl;
+        Logger(LOG_ERROR) << "[ConnectionManager::add] epoll_ctl: " << strerror(errno);
         return 1;
     };
     _handlers[h->fd()] = h;
@@ -56,7 +55,7 @@ int ConnectionManager::mod(IHandler* h) {
 
     // Switch epolls' behavior on wanted fd (EPOLLIN/OUT)
     if (epoll_ctl(_epfd, EPOLL_CTL_MOD, h->fd(), &ev) != 0) {
-        std::cerr << "[ConnectionManager::mod] epoll_ctl: " << strerror(errno) << std::endl;
+        Logger(LOG_ERROR) << "[ConnectionManager::mod] epoll_ctl: " << strerror(errno);
         return 1;
     }
     return 0;
@@ -69,9 +68,9 @@ void ConnectionManager::del(IHandler* h) {
 
     // Remove fd from epoll
     if (epoll_ctl(_epfd, EPOLL_CTL_DEL, fd, NULL) != 0)
-        std::cerr << "[ConnectionManager::del] epoll_ctl: " << strerror(errno) << std::endl;
+        Logger(LOG_ERROR) << "[ConnectionManager::del] epoll_ctl: " << strerror(errno);
     _handlers.erase(it);
-    std::cout << "[ConnectionManager] Closing fd=" << fd << std::endl;
+    Logger(LOG_GENERAL) << "[ConnectionManager] Closing fd=" << fd;
     close(fd);
     delete h;
 }
@@ -83,7 +82,7 @@ void ConnectionManager::run() {
         // returns the amount of fds ready for io operations
         int fds = epoll_wait(_epfd, events, 64, 10000);
         if (fds < 0) {
-            std::cerr << "[ConnectionManager::run] epoll_wait: " << strerror(errno) << std::endl;
+            Logger(LOG_ERROR) << "[ConnectionManager::run] epoll_wait: " << strerror(errno);
             continue;
         }
 
@@ -105,7 +104,7 @@ void ConnectionManager::run() {
             IHandler* h = it->second;
 
             if (h->is_timed_out()) {
-                std::cout << "[TIMEOUT] fd=" << h->fd() << std::endl;
+                Logger(LOG_GENERAL) << "[TIMEOUT] fd=" << h->fd();
                 ++it;
                 del(h);
             } else {

--- a/src/ConnectionManager/ConnectionManager.cpp
+++ b/src/ConnectionManager/ConnectionManager.cpp
@@ -87,11 +87,11 @@ void ConnectionManager::run() {
             continue;
         }
 
-        std::cout << "[EPOLL] woke up with " << fds << " events" << std::endl;
+        // Commented to avoid spamming console/logs
+        // std::cout << "[EPOLL] woke up with " << fds << " events" << std::endl;
 
         for (int i = 0; i < fds; ++i) {
             IHandler* h = (IHandler*)events[i].data.ptr;
-            std::cout << "[EPOLL] fd=" << h->fd() << " events=" << events[i].events << std::endl;
             // Keep or delete connection
             bool keep = h->handle_event(*this, events[i].events);
             if (!keep) {

--- a/src/ConnectionManager/Listener.cpp
+++ b/src/ConnectionManager/Listener.cpp
@@ -4,10 +4,9 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-#include <iostream>
-
 #include "ConnectionHandler.hpp"
 #include "ConnectionManager.hpp"
+#include "Logger.hpp"
 #include "socket_utils.hpp"
 
 Listener::Listener(const ConfigServer* srv, int listen_fd) : _srv(srv), _fd(listen_fd) {}
@@ -22,7 +21,7 @@ uint32_t Listener::interests() const {
 
 bool Listener::handle_event(ConnectionManager& manager, uint32_t events) {
     if (events & (EPOLLERR | EPOLLHUP)) {
-        std::cerr << "[LISTENER " << _fd << "] Error: Wrong epoll event";
+        Logger(LOG_ERROR) << "[LISTENER " << _fd << "] Error: Wrong epoll event";
         return false;
     }
 
@@ -38,7 +37,7 @@ bool Listener::handle_event(ConnectionManager& manager, uint32_t events) {
             continue;
         }
 
-        std::cout << "[LISTENER] New client accepted fd=" << client_fd << std::endl;
+        Logger(LOG_GENERAL) << "[LISTENER] New client accepted fd=" << client_fd;
 
         manager.add(new ConnectionHandler(_srv, client_fd));
     }

--- a/src/ConnectionManager/Request.cpp
+++ b/src/ConnectionManager/Request.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "Logger.hpp"
 #include "config.hpp"
 #include "file_manager.hpp"
 
@@ -134,7 +135,7 @@ bool Request::open_temp_body_file() {
     if (_body_fd >= 0) return true;
 
     if (is_directory("tmp") == false) {
-        std::cerr << "[Request::open_temp_body_file] tmp directory missing\n";
+        Logger(LOG_ERROR) << "[Request::open_temp_body_file] tmp directory missing\n";
         return false;
     }
 
@@ -159,7 +160,7 @@ bool Request::open_temp_body_file() {
             return false;
         }
     }
-    std::cerr << "[open_temp_body_file] failed to create unique temp file" << std::endl;
+    Logger(LOG_ERROR) << "[open_temp_body_file] failed to create unique temp file";
     return false;
 }
 

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -1,0 +1,47 @@
+#include "Logger.hpp"
+
+#include <ctime>
+#include <fstream>
+#include <string>
+
+/**
+ * @brief The functions Open and return the log files in "append" mode.
+ */
+static std::ofstream& get_debug_file() {
+    static std::ofstream ofs("log_debug.log", std::ios::app);
+    return ofs;
+}
+
+static std::ofstream& get_general_file() {
+    static std::ofstream ofs("log_general.log", std::ios::app);
+    return ofs;
+}
+
+static std::ofstream& get_error_file() {
+    static std::ofstream ofs("log_error.log", std::ios::app);
+    return ofs;
+}
+
+static std::string get_timestamp() {
+    std::time_t t = std::time(NULL);
+    char        buf[64];
+
+    std::strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", std::localtime(&t));
+    return std::string(buf);
+}
+
+static void write_log(std::ofstream& ofs, const std::string& msg) {
+    ofs << "[" << get_timestamp() << "] " << msg << std::endl;
+}
+
+static void dispatch_log(LogLevel level, const std::string& msg) {
+    if (level >= DEBUGLOG) write_log(get_debug_file(), msg);
+    if (level >= GENERALLOG) write_log(get_general_file(), msg);
+    if (level >= ERRORLOG) write_log(get_error_file(), msg);
+}
+
+Logger::Logger(LogLevel level) : _level(level) {}
+
+Logger::~Logger() {
+    dispatch_log(_level, _oss.str());
+}

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -35,9 +35,9 @@ static void write_log(std::ofstream& ofs, const std::string& msg) {
 }
 
 static void dispatch_log(LogLevel level, const std::string& msg) {
-    if (level >= DEBUG_LOG) write_log(get_debug_file(), msg);
-    if (level >= GENERAL_LOG) write_log(get_general_file(), msg);
-    if (level >= ERROR_LOG) write_log(get_error_file(), msg);
+    if (level >= LOG_DEBUG) write_log(get_debug_file(), msg);
+    if (level >= LOG_GENERAL) write_log(get_general_file(), msg);
+    if (level >= LOG_ERROR) write_log(get_error_file(), msg);
 }
 
 Logger::Logger(LogLevel level) : _level(level) {}

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -35,9 +35,9 @@ static void write_log(std::ofstream& ofs, const std::string& msg) {
 }
 
 static void dispatch_log(LogLevel level, const std::string& msg) {
-    if (level >= DEBUGLOG) write_log(get_debug_file(), msg);
-    if (level >= GENERALLOG) write_log(get_general_file(), msg);
-    if (level >= ERRORLOG) write_log(get_error_file(), msg);
+    if (level >= DEBUG_LOG) write_log(get_debug_file(), msg);
+    if (level >= GENERAL_LOG) write_log(get_general_file(), msg);
+    if (level >= ERROR_LOG) write_log(get_error_file(), msg);
 }
 
 Logger::Logger(LogLevel level) : _level(level) {}

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -40,6 +40,12 @@ static void dispatch_log(LogLevel level, const std::string& msg) {
     if (level >= LOG_ERROR) write_log(get_error_file(), msg);
 }
 
+void logger_init() {
+    std::ofstream("log_debug.log", std::ios::trunc).close();
+    std::ofstream("log_general.log", std::ios::trunc).close();
+    std::ofstream("log_error.log", std::ios::trunc).close();
+}
+
 Logger::Logger(LogLevel level) : _level(level) {}
 
 Logger::~Logger() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include "ConfigParser.hpp"
 #include "ConnectionManager.hpp"
 #include "Listener.hpp"
+#include "Logger.hpp"
 #include "config.hpp"
 #include "file_manager.hpp"
 #include "socket_utils.hpp"
@@ -39,15 +40,15 @@ int main(int argc, char** argv) {
     try {
         config = parse_file(config_file);
     } catch (const ParserError& e) {
-        std::cerr << "[!] - " << e.what() << std::endl;
+        Logger(LOG_ERROR) << "[!] - " << e.what();
         return 3;
     }
     config_file.close();
 
     ConnectionManager manager;
     for (ServerIterator s = config.server.begin(); s != config.server.end(); ++s) {
-        const ConfigServer&  server_config = *s;
-        std::vector<int>     listen_fds;
+        const ConfigServer& server_config = *s;
+        std::vector<int>    listen_fds;
         try {
             listen_fds = make_listen_sockets(server_config);
         } catch (...) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ void clean_exit(int) {
 int main(int argc, char** argv) {
     if (argc != 2) return 1;
 
+    logger_init();
     signal(SIGINT, clean_exit);
 
     if (!is_regular_file(argv[1])) {


### PR DESCRIPTION
## Summary

This PR adds a logger system to replace console/error outputs. It will write to `log_level.log` files. Levels are stored in an enum (`LOG_DEBUG`, `LOG_GENERAL`, `LOG_ERROR`), they are easy to swap or rework if needed. Anything written in a higher level will be written in the lower ones too.

Log files are flushed on webserv's startup.

## Usage

```
Logger(LOG_DEBUG) << "String 1 " << _fd << " Whatever" << e.what();
```
## Output
```
[2026-04-10 17:37:14] String 1 5 Whatever
```
Note that the Logger automatically adds the endline at the end.

We probably need to rework all of our log prints, move them elsewhere or remove ones that are no longer useful. Let me know what you think of this.