### PR TITLE
fix/use error_log directive as a log folder

### DIFF
--- a/include/Logger.hpp
+++ b/include/Logger.hpp
@@ -24,6 +24,6 @@ private:
     std::ostringstream _oss;
 };
 
-void logger_init();
+void logger_init(const std::string& log_dir);
 
 #endif

--- a/src/ConfigParser/config_parser.cpp
+++ b/src/ConfigParser/config_parser.cpp
@@ -88,8 +88,8 @@ static int check_listen(const Config& config) {
 
 static void check_config(const Config& config) {
     if (config.error_log.empty() == false) {
-        std::ofstream error_log(config.error_log.c_str());
-        if (!error_log) throw ParserError("Invalid error_log directive");
+        if (is_directory(config.error_log) == false)
+            throw ParserError("Invalid error_log directive, not a directory");
     }
 
     if (check_listen(config) != 0) throw ParserError("Duplicate listen directive");

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -46,13 +46,14 @@ static void dispatch_log(LogLevel level, const std::string& msg) {
 }
 
 void logger_init(const std::string& log_dir) {
+    const std::string& log_directory = get_log_directory();
     if (log_dir.empty())
-        get_log_directory() = ".";
+        log_directory = ".";
     else
-        get_log_directory() = log_dir;
-    std::ofstream((get_log_directory() + "/log_debug.log").c_str(), std::ios::trunc).close();
-    std::ofstream((get_log_directory() + "/log_general.log").c_str(), std::ios::trunc).close();
-    std::ofstream((get_log_directory() + "/log_error.log").c_str(), std::ios::trunc).close();
+        log_directory = log_dir;
+    std::ofstream((log_directory + "/log_debug.log").c_str(), std::ios::trunc).close();
+    std::ofstream((log_directory + "/log_general.log").c_str(), std::ios::trunc).close();
+    std::ofstream((log_directory + "/log_error.log").c_str(), std::ios::trunc).close();
 }
 
 Logger::Logger(LogLevel level) : _level(level) {}

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -4,21 +4,26 @@
 #include <fstream>
 #include <string>
 
+static std::string& get_log_directory() {
+    static std::string log_dir;
+    return log_dir;
+}
+
 /**
  * @brief The functions Open and return the log files in "append" mode.
  */
 static std::ofstream& get_debug_file() {
-    static std::ofstream ofs("log_debug.log", std::ios::app);
+    static std::ofstream ofs((get_log_directory() + "/log_debug.log").c_str(), std::ios::app);
     return ofs;
 }
 
 static std::ofstream& get_general_file() {
-    static std::ofstream ofs("log_general.log", std::ios::app);
+    static std::ofstream ofs((get_log_directory() + "/log_general.log").c_str(), std::ios::app);
     return ofs;
 }
 
 static std::ofstream& get_error_file() {
-    static std::ofstream ofs("log_error.log", std::ios::app);
+    static std::ofstream ofs((get_log_directory() + "/log_error.log").c_str(), std::ios::app);
     return ofs;
 }
 
@@ -40,10 +45,14 @@ static void dispatch_log(LogLevel level, const std::string& msg) {
     if (level >= LOG_ERROR) write_log(get_error_file(), msg);
 }
 
-void logger_init() {
-    std::ofstream("log_debug.log", std::ios::trunc).close();
-    std::ofstream("log_general.log", std::ios::trunc).close();
-    std::ofstream("log_error.log", std::ios::trunc).close();
+void logger_init(const std::string& log_dir) {
+    if (log_dir.empty())
+        get_log_directory() = ".";
+    else
+        get_log_directory() = log_dir;
+    std::ofstream((get_log_directory() + "/log_debug.log").c_str(), std::ios::trunc).close();
+    std::ofstream((get_log_directory() + "/log_general.log").c_str(), std::ios::trunc).close();
+    std::ofstream((get_log_directory() + "/log_error.log").c_str(), std::ios::trunc).close();
 }
 
 Logger::Logger(LogLevel level) : _level(level) {}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,6 @@ void clean_exit(int) {
 int main(int argc, char** argv) {
     if (argc != 2) return 1;
 
-    logger_init();
     signal(SIGINT, clean_exit);
 
     if (!is_regular_file(argv[1])) {
@@ -45,6 +44,8 @@ int main(int argc, char** argv) {
         return 3;
     }
     config_file.close();
+
+    logger_init(config.error_log);
 
     ConnectionManager manager;
     for (ServerIterator s = config.server.begin(); s != config.server.end(); ++s) {


### PR DESCRIPTION
#52 

Changes to use `error_log` to specify a folder to store logs in