### PR TITLE
Feat/resolve path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ CFILES		=	$(SRCDIR)/main.cpp \
 				$(SRCDIR)/FileManager/helpers.cpp \
 				$(SRCDIR)/FileManager/listing.cpp \
 				$(SRCDIR)/FileManager/read.cpp \
+				$(SRCDIR)/FileManager/resolve.cpp \
 				$(SRCDIR)/FileManager/write.cpp \
 				$(SRCDIR)/RequestParser/request_parser.cpp \
 				$(SRCDIR)/RequestParser/helpers.cpp \

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,10 @@ CFILES		=	$(SRCDIR)/main.cpp \
 				$(SRCDIR)/ConnectionManager/Listener.cpp \
 				$(SRCDIR)/ConnectionManager/Request.cpp \
 				$(SRCDIR)/ConnectionManager/Response.cpp \
+				$(SRCDIR)/FileManager/helpers.cpp \
+				$(SRCDIR)/FileManager/listing.cpp \
 				$(SRCDIR)/FileManager/read.cpp \
 				$(SRCDIR)/FileManager/write.cpp \
-				$(SRCDIR)/FileManager/listing.cpp \
 				$(SRCDIR)/RequestParser/request_parser.cpp \
 				$(SRCDIR)/RequestParser/helpers.cpp \
 				$(SRCDIR)/socket_utils.cpp \

--- a/include/file_manager.hpp
+++ b/include/file_manager.hpp
@@ -33,5 +33,6 @@ std::string                   create_listing(const FilePath&);
 std::string resolve_path(const FilePath& relative_path, const std::string& root);
 
 std::vector<std::string> split(const std::string& s, char delimiter);
+bool                     is_under_directory(const FilePath& path, const FilePath& directory);
 
 #endif  // FILEMANAGER_HPP

--- a/include/file_manager.hpp
+++ b/include/file_manager.hpp
@@ -31,8 +31,8 @@ std::map<FilePath, Path_Type> get_dir_contents(const FilePath&);
 std::string                   create_listing(const FilePath&);
 
 std::string resolve_path(const FilePath& relative_path, const std::string& root);
+bool        is_under_directory(const FilePath& path, const FilePath& directory);
 
 std::vector<std::string> split(const std::string& s, char delimiter);
-bool                     is_under_directory(const FilePath& path, const FilePath& directory);
 
 #endif  // FILEMANAGER_HPP

--- a/include/file_manager.hpp
+++ b/include/file_manager.hpp
@@ -5,7 +5,9 @@
 
 #include <map>
 #include <string>
+#include <vector>
 
+// An absolute path to a point on the file system
 typedef std::string FilePath;
 
 // Stores the working directory of the server
@@ -27,5 +29,9 @@ int     remove_file(const FilePath&);
 
 std::map<FilePath, Path_Type> get_dir_contents(const FilePath&);
 std::string                   create_listing(const FilePath&);
+
+std::string resolve_path(const FilePath& relative_path, const std::string& root);
+
+std::vector<std::string> split(const std::string& s, char delimiter);
 
 #endif  // FILEMANAGER_HPP

--- a/include/file_manager.hpp
+++ b/include/file_manager.hpp
@@ -8,6 +8,9 @@
 
 typedef std::string FilePath;
 
+// Stores the working directory of the server
+extern FilePath working_directory;
+
 /**
  * @brief Defines the type of a FilePath, whether it is a standard file or a folder.
  */

--- a/src/ConfigParser/config_parser.cpp
+++ b/src/ConfigParser/config_parser.cpp
@@ -9,7 +9,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <iostream>
 #include <map>
 #include <sstream>
 #include <string>
@@ -362,7 +361,8 @@ ConfigLocation parse_location(TokenIterator* t, TokenIterator end) {
             } else if (directive == "index") {
                 if (tokens.size() < 3)
                     throw ParserError(tokens[0], "Wrong number of tokens in index directive");
-                config.index = config.root + "/" + standardize_path(tokens[1].word);
+                // FIXME What happens when config.root isn't set yet?
+                config.index = config.root + "/" + tokens[1].word;
             } else if (directive == "redirect") {
                 if (tokens.size() != 4)
                     throw ParserError(tokens[0], "Wrong number of tokens in redirect directive");

--- a/src/ConnectionManager/request_parser.cpp
+++ b/src/ConnectionManager/request_parser.cpp
@@ -1,0 +1,280 @@
+#include <cassert>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "Request.hpp"
+
+static std::string trim(const std::string& s) {
+    const std::string whitespace = " \t\n\r\f\v";
+
+    size_t start = s.find_first_not_of(whitespace);
+    if (start == std::string::npos) return "";
+
+    size_t end = s.find_last_not_of(whitespace);
+
+    return s.substr(start, end - start + 1);
+}
+
+// TODO Replace with generic split function in file manager helpers
+static std::vector<std::string> split_header_values(const std::string& value) {
+    std::vector<std::string> result;
+    size_t                   start = 0;
+
+    while (start < value.size()) {
+        size_t comma = value.find(',', start);
+
+        // push final value
+        if (comma == std::string::npos) {
+            std::string end = trim(value.substr(start));
+            if (!end.empty()) result.push_back(end);
+            break;
+        }
+
+        // push trimmed value
+        std::string trimmed = trim(value.substr(start, comma - start));
+        if (!trimmed.empty()) result.push_back(trimmed);
+
+        start = comma + 1;
+    }
+
+    return result;
+}
+
+static bool parse_content_length_value(const std::string& value, size_t& out) {
+    if (value.empty()) return false;
+
+    for (size_t i = 0; i < value.size(); ++i) {
+        if (!std::isdigit(static_cast<unsigned char>(value[i]))) return false;
+    }
+
+    std::istringstream stream(value);
+    unsigned long      parsed = 0;
+    stream >> parsed;
+    if (!stream || !stream.eof()) return false;
+    if (parsed > std::numeric_limits<size_t>::max()) return false;
+
+    out = static_cast<size_t>(parsed);
+    return true;
+}
+
+static RequestStatus parse_request_line(const std::string& read_buffer, size_t& read_index,
+                                        Request& request) {
+    assert(request.status() == REQ_EMPTY);
+
+    std::string::size_type line_end = read_buffer.find("\r\n", read_index);
+    if (line_end == std::string::npos) return request.status();
+
+    std::string line = read_buffer.substr(read_index, line_end - read_index);
+
+    // String to stream for easy parse
+    std::istringstream stream(line);
+    std::string        method;
+    std::string        target;
+    std::string        version;
+    std::string        extra;
+
+    // Fills values seperated by spaces. If extra succeeds after, Error.
+    if (!(stream >> method >> target >> version) || (stream >> extra)) {
+        request.set_status(REQ_ERROR);
+        request.set_error_status(400);  // Bad request 400, too many/too few elements
+        return request.status();
+    }
+    if (method == "GET")
+        request.set_method(GET);
+    else if (method == "POST")
+        request.set_method(POST);
+    else if (method == "DELETE")
+        request.set_method(DELETE);
+    else {
+        request.set_status(REQ_ERROR);
+        request.set_error_status(501);  // Not implemented
+        request.set_method(UNDEFINED);
+    }
+
+    request.set_target(target);
+
+    if (version != "HTTP/1.1") {
+        request.set_status(REQ_ERROR);
+        request.set_error_status(505);  // HTTP version unsupported
+        return request.status();
+    }
+    request.set_version(1, 1);
+
+    read_index = line_end + 2;  // skip \r\n
+    request.set_status(REQ_REQUEST_LINE);
+
+    return request.status();
+}
+
+static bool handle_content_length_header(Request& request) {
+    size_t content_length = 0;
+
+    for (HttpMessage::HeaderIterator it = request.headers_begin(); it != request.headers_end();
+         ++it) {
+        if (it->first == "Content-Length") {
+            if (!parse_content_length_value(it->second, content_length)) {
+                request.set_error_status(400);
+                request.set_status(REQ_ERROR);
+                return false;
+            }
+        }
+    }
+    request.set_content_length(content_length);
+
+    if (content_length > request.client_max_body_size()) {
+        request.set_error_status(413);
+        request.set_status(REQ_ERROR);
+        return false;
+    }
+    if (content_length > 0) {
+        request.set_status(REQ_HEADERS);
+        return false;
+    }
+    return true;
+}
+
+static bool is_header_unique(Request& request, const std::string& key) {
+    size_t count = 0;
+
+    for (HttpMessage::HeaderIterator it = request.headers_begin(); it != request.headers_end();
+         ++it) {
+        if (it->first == key) {
+            ++count;
+            if (count > 1) return false;
+        }
+    }
+    return true;
+}
+
+// TODO This function really needs an overhaul. It's long and hard to read
+static RequestStatus parse_headers(const std::string& read_buffer, size_t& read_index,
+                                   Request& request) {
+    assert(request.status() == REQ_REQUEST_LINE);
+
+    while (true) {
+        // Find \r\n, will return npos if not found. Means it didn't finish parsing headers
+        std::string::size_type line_end = read_buffer.find("\r\n", read_index);
+        if (line_end == std::string::npos) return request.status();
+
+        // Empty line, end of headers. Set index after \r\n
+        if (line_end == read_index) {
+            read_index += 2;
+
+            // Check for mandatory Host header, and if it is unique.
+            if (!request.has_header("Host") || !is_header_unique(request, "Host")) {
+                request.set_error_status(400);
+                request.set_status(REQ_ERROR);
+                return request.status();
+            }
+            if (!handle_content_length_header(request)) return request.status();
+            request.set_status(REQ_BODY);
+            return request.status();
+        }
+        // retrieve each line without \r\n
+        std::string            line = read_buffer.substr(read_index, line_end - read_index);
+        std::string::size_type colon = line.find(':');
+        if (colon == std::string::npos) {
+            request.set_status(REQ_ERROR);
+            request.set_error_status(400);
+            return request.status();  // Error
+        }
+
+        std::string key = trim(line.substr(0, colon));
+        std::string value = trim(line.substr(colon + 1));
+        // Not all headers must be split
+        std::vector<std::string> values;
+        if (key == "Set-Cookie")
+            values.push_back(value);
+        else
+            values = split_header_values(value);
+
+        if (values.empty()) {
+            request.set_header(key, "");
+        } else {
+            for (size_t i = 0; i < values.size(); ++i) request.set_header(key, values[i]);
+        }
+        read_index = line_end + 2;  // skip \r\n
+    }
+}
+
+static RequestStatus parse_body(const std::string& read_buffer, size_t& read_index,
+                                Request& request) {
+    assert(request.status() == REQ_HEADERS);
+
+    size_t expected = request.content_length();
+    size_t received = request.body_received();
+
+    if (received > expected) {
+        request.set_error_status(400);
+        request.set_status(REQ_ERROR);
+        return request.status();
+    }
+
+    size_t remaining = expected - received;
+    size_t available = read_buffer.size() - read_index;
+    size_t chunk = std::min(remaining, available);
+
+    if (chunk == 0) return request.status();
+
+    if (!request.append_body_chunk(read_buffer.data() + read_index, chunk)) {
+        request.set_error_status(500);
+        request.set_status(REQ_ERROR);
+        return request.status();
+    }
+
+    read_index += chunk;
+
+    if (request.body_received() == expected) request.set_status(REQ_BODY);
+
+    return request.status();
+}
+
+/**
+ * @brief Resolves which location config should be assigned to the given request, based on its
+ * target.
+ * It resolves in order, but the most precise location found will be set.
+ * For example, if the target of the request is /images, but there are / and /images locations in
+ * the configuration, the /images location will be choosen, even though / comes before
+ * alphabetically.
+ */
+static RequestStatus resolve_location(const ConfigServer& config, Request& request) {
+    assert(request.status() == REQ_BODY);
+
+    const std::string& request_target = request.target();
+    bool               matched = false;
+
+    for (LocationIterator l = config.location.begin(); l != config.location.end(); ++l) {
+        const std::string& location_name = l->first;
+        const size_t       location_length = location_name.length();
+
+        // If the target matches a location, even just as a prefix, then it's the right location
+        if (request_target.substr(0, location_length) == location_name) {
+            request.set_config(&l->second);
+            matched = true;
+        }
+    }
+
+    if (!matched) {
+        request.set_error_status(404);
+        request.set_status(REQ_ERROR);
+    } else {
+        request.set_status(REQ_PARSED);
+    }
+    return request.status();
+}
+
+RequestStatus parse(const ConfigServer& config, std::string& read_buffer, size_t& read_index,
+                    Request& request) {
+    if (request.status() == REQ_EMPTY) parse_request_line(read_buffer, read_index, request);
+
+    if (request.status() == REQ_REQUEST_LINE) parse_headers(read_buffer, read_index, request);
+
+    if (request.status() == REQ_HEADERS) parse_body(read_buffer, read_index, request);
+
+    if (request.status() == REQ_BODY) resolve_location(config, request);
+
+    return request.status();
+}

--- a/src/FileManager/helpers.cpp
+++ b/src/FileManager/helpers.cpp
@@ -1,0 +1,24 @@
+#include <cassert>
+#include <string>
+#include <vector>
+
+/**
+ * @brief Splits a string on a delimiter. No empty tokens are returned when delimiters follow each
+ * other (for example: `split("path//to///file", '/')` would only give you `path`, `to` and `file`).
+ */
+std::vector<std::string> split(const std::string& s, char delimiter) {
+    assert(s.empty() == false && "Empty string");
+
+    std::vector<std::string> split_tokens;
+    size_t                   index = s.find_first_not_of(delimiter);
+
+    while (index < s.size()) {
+        size_t new_index = s.find(delimiter, index);
+        split_tokens.push_back(s.substr(index, new_index - index));
+
+        index = new_index;
+        while (index < s.size() && s[index] == delimiter) ++index;
+    }
+
+    return split_tokens;
+}

--- a/src/FileManager/read.cpp
+++ b/src/FileManager/read.cpp
@@ -5,6 +5,9 @@
 #include <cassert>
 #include <cstdio>
 #include <cstring>
+#include <stack>
+#include <string>
+#include <vector>
 
 #include "file_manager.hpp"
 
@@ -64,15 +67,35 @@ bool is_directory(const FilePath& path) {
  *
  * @description Removes a potential trailing slash.
  */
+// TODO Need to standardize to absolute paths.
 FilePath standardize_path(const std::string& path) {
     assert(path.empty() == false && "Empty path");
 
-    std::string standardized = path;
+    // First split on /
+    std::vector<std::string> split_tokens = split(path, '/');
 
-    if (standardized.at(standardized.size() - 1) == '/') {
-        standardized.erase(standardized.size() - 1, standardized.size());
+    std::stack<std::string> s;
+    for (size_t index = 0; index < split_tokens.size(); ++index) {
+        if (split_tokens[index] == ".")
+            ;
+        else if (split_tokens[index] == "..") {
+            if (s.empty() == false) s.pop();
+        } else {
+            s.push(split_tokens[index]);
+        }
     }
 
+    // Finally concatenate into a full, absolute path
+    FilePath standardized;
+    while (s.empty() == false) {
+        std::string token = s.top();
+        token.insert(0, "/");
+        standardized.insert(0, token);
+
+        s.pop();
+    }
+
+    if (path[0] != '/') standardized.insert(0, working_directory);
     return standardized;
 }
 

--- a/src/FileManager/read.cpp
+++ b/src/FileManager/read.cpp
@@ -67,7 +67,6 @@ bool is_directory(const FilePath& path) {
  *
  * @description Removes a potential trailing slash.
  */
-// TODO Need to standardize to absolute paths.
 FilePath standardize_path(const std::string& path) {
     assert(path.empty() == false && "Empty path");
 

--- a/src/FileManager/resolve.cpp
+++ b/src/FileManager/resolve.cpp
@@ -18,3 +18,23 @@ FilePath resolve_path(const std::string& relative_path, const FilePath& root) {
 
     return resolved_path;
 }
+
+/**
+ * @brief This functions checks whether a path is "under" a directory, that is, whether it is
+ * contained within it or one of its subdirectories.
+ *
+ * @description Important: Both arguments must be standardized, absolute paths.
+ * It is worth noting that the directory itself is considered to be "under" itself (as `.`).
+ * Also worth noting that this function does not check for the existence of a file at `path`, and
+ * will return true if the path is theorically under the directory.
+ *
+ * @see standardize_path()
+ */
+bool is_under_directory(const FilePath& path, const FilePath& directory) {
+    if (directory.length() > path.length()) return false;
+
+    for (size_t i = 0; i < directory.length(); ++i) {
+        if (directory[i] != path[i]) return false;
+    }
+    return true;
+}

--- a/src/FileManager/resolve.cpp
+++ b/src/FileManager/resolve.cpp
@@ -1,0 +1,20 @@
+#include <cassert>
+#include <string>
+
+#include "file_manager.hpp"
+
+/**
+ * @brief Based on a root, resolves a relative path.
+ *
+ * In effect, this follows the `relative_path` from the directory `root`.
+ * Careful, depending on the relative_path, this could land you above the root, which you don't want
+ * for resolving HTTP requests' targets.
+ */
+FilePath resolve_path(const std::string& relative_path, const FilePath& root) {
+    assert(relative_path[0] != '/' && "relative_path must be relative (not start with a slash)");
+
+    std::string unresolved_path = root + "/" + relative_path;
+    std::string resolved_path = standardize_path(unresolved_path);
+
+    return resolved_path;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 
 #include <csignal>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -20,6 +21,8 @@
 
 volatile sig_atomic_t g_stop = 0;
 
+FilePath working_directory;
+
 void clean_exit(int) {
     g_stop = 1;
 }
@@ -28,6 +31,11 @@ int main(int argc, char** argv) {
     if (argc != 2) return 1;
 
     signal(SIGINT, clean_exit);
+
+    // TODO Replace forbidden getcwd with our own function
+    char* cwd = getcwd(NULL, 0);
+    working_directory = cwd;
+    free(cwd);
 
     if (!is_regular_file(argv[1])) {
         std::cerr << "[!] - Failed to open configuration file." << std::endl;


### PR DESCRIPTION
This PR adds a few utilities and enhances an existing one of the File Manager, in preparation for the Request Processor to be actually built.

# Main changes
- Better `standardize_path`, which now resolves any relative path to its absolute equivalent.
- `resolve_path` and `is_under_directory` helper functions that will both be useful for the Request Processor later on.
- Store the current working directory of the web server as a global