### PR TITLE
ConPar: Location configs now store their name as part of the struct

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -22,6 +22,8 @@ enum HttpMethod { UNDEFINED, GET, POST, DELETE };
 typedef struct ConfigLocation {
     ConfigLocation();
 
+    std::string name;
+
     std::set<HttpMethod>            allowed_methods;
     bool                            autoindex;
     std::map<std::string, FilePath> cgi;  // Bind an extension to an interpreter

--- a/src/ConfigParser/config_parser.cpp
+++ b/src/ConfigParser/config_parser.cpp
@@ -9,7 +9,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
-#include <iostream>
 #include <map>
 #include <sstream>
 #include <string>
@@ -295,8 +294,10 @@ ConfigServer parse_server(TokenIterator* t, TokenIterator end) {
             } else if (directive == "location") {
                 if (tokens.size() != 3)
                     throw ParserError(tokens[0], "Wrong number of tokens in location directive");
-                config.location.insert(std::pair<std::string, ConfigLocation>(
-                    tokens[1].word, parse_location((t), end)));
+                ConfigLocation location = parse_location(t, end);
+                location.name = tokens[1].word;
+                config.location.insert(
+                    std::pair<std::string, ConfigLocation>(tokens[1].word, location));
             } else if (directive == "timeout") {
                 if (tokens.size() != 3)
                     throw ParserError(tokens[0], "Wrong number of tokens in timeout directive");


### PR DESCRIPTION
This will be useful when building the request processor, since when you only have access to a ConfigLocation instance (inside of Request objects, for instance), you don't know what key it's under in the map of ConfigServer.