### PR TITLE
Feat/408 timeout

### DIFF
--- a/include/ConnectionHandler.hpp
+++ b/include/ConnectionHandler.hpp
@@ -16,8 +16,10 @@ public:
 
     virtual int      fd() const;
     virtual uint32_t interests() const;
-    virtual bool     handle_event(ConnectionManager& manager, uint32_t events);
     virtual bool     is_timed_out() const;
+
+    void         timeout_connection();
+    virtual bool handle_event(ConnectionManager& manager, uint32_t events);
 
 private:
     int         _fd;

--- a/include/IHandler.hpp
+++ b/include/IHandler.hpp
@@ -12,7 +12,7 @@ public:
     virtual int      fd() const = 0;
     virtual uint32_t interests() const = 0;
 
-    // ConnectionManager deletes on false return (epoll DEL + close + delete)
+    // ConnectionManager deletes on this function returning false (epoll DEL + close + delete)
     virtual bool handle_event(ConnectionManager& manager, uint32_t events) = 0;
 
     virtual bool is_timed_out() const;

--- a/src/ConnectionManager/Connection.cpp
+++ b/src/ConnectionManager/Connection.cpp
@@ -82,8 +82,6 @@ ssize_t Connection::receive_data() {
             return -1;
         }
     }
-    // if (total > 0)
-    //     std::cout << "[CONN " << _socket << "] received " << total << " bytes" << std::endl;
 
     return total;
 }

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -9,6 +9,7 @@
 #include "ConnectionManager.hpp"
 #include "Logger.hpp"
 #include "Request.hpp"
+#include "Response.hpp"
 #include "config.hpp"
 
 static std::string hello_response() {
@@ -70,8 +71,26 @@ uint32_t ConnectionHandler::interests() const {
         return EPOLLIN;
 }
 
+/**
+ * @brief Checks whether a connection has been timed out or not.
+ * This is directly based on the `timeout` directive in the server configuration.
+ * If this is set to 0 (as is the default), any incoming data that isn't immediately parsed to a
+ * full request will result in a connection close.
+ */
 bool ConnectionHandler::is_timed_out() const {
     return (std::time(NULL) - _last_activity) > _timeout;
+}
+
+/**
+ * @brief After a conneciton has timed out, this member function will generate and send a 408 error
+ * response before the Connection Manager closes the connection outright.
+ */
+void ConnectionHandler::timeout_connection() {
+    Logger(LOG_DEBUG) << "[!] - Timing connection out!";
+    _conn.set_response(error_response(408));
+    _conn.queue_write(_conn.response().serialize());
+    _conn.queue_write(_conn.response().body());
+    _conn.send_data();
 }
 
 /**
@@ -91,8 +110,6 @@ bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events
         return false;
     }
 
-    // FIXME For some reason the connection is closed without a message when only sending the
-    // request line over telnet/netcat
     if (events & EPOLLIN) {
         ssize_t n = _conn.receive_data();
         if (n <= 0) return false;

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -83,40 +83,39 @@ bool ConnectionHandler::is_timed_out() const {
  */
 bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events) {
     (void)manager;
+    const Request&  request = _conn.request();
+    const Response& response = _conn.response();
 
     if (events & (EPOLLERR | EPOLLHUP)) {
         Logger(LOG_ERROR) << "[CONN " << _fd << "] Error: Wrong epoll event";
         return false;
     }
 
+    // FIXME For some reason the connection is closed without a message when only sending the
+    // request line over telnet/netcat
     if (events & EPOLLIN) {
         ssize_t n = _conn.receive_data();
+        if (n <= 0) return false;
 
-        if (n < 0) return false;
-        if (n == 0) return false;  // temp to avoid infinite calls when closed by client
+        _conn.parse_request();
+    }
 
-        RequestStatus status = _conn.parse_request();
-        log_request(_conn.request());
-
-        // Add data to send depending on state
-        if (!_conn.has_pending_write()) {
-            if (status == REQ_PARSED) {
-                _conn.queue_write(hello_response());
-            } else if (status == REQ_ERROR) {
-                HttpCode code = _conn.request().error_status();
-                _conn.set_response(error_response(code));
-                // TODO Temporary, will have to be swapped with RePro logic
-                _conn.queue_write(_conn.response().serialize());
-                _conn.queue_write(_conn.response().body());
-            }
+    // Add data to send depending on state
+    if (!_conn.has_pending_write()) {
+        if (request.status() == REQ_PARSED) {
+            log_request(request);
+            _conn.queue_write(hello_response());
+        } else if (request.status() == REQ_ERROR) {
+            log_request(request);
+            HttpCode code = request.error_status();
+            _conn.set_response(error_response(code));
+            // TODO Temporary, will have to be swapped with RePro logic
+            _conn.queue_write(response.serialize());
+            _conn.queue_write(response.body());
         }
     }
-    // Send data
-    if ((events & EPOLLOUT) && _conn.has_pending_write()) {
-        _conn.send_data();
-        // temp, close connection once all data was sent
-        if (!_conn.has_pending_write()) return false;
-    }
 
-    return true;  // keeps connection
+    if (events & EPOLLOUT && _conn.has_pending_write()) _conn.send_data();
+
+    return true;
 }

--- a/src/ConnectionManager/ConnectionManager.cpp
+++ b/src/ConnectionManager/ConnectionManager.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstring>
 
+#include "ConnectionHandler.hpp"
 #include "Logger.hpp"
 #include "signal_state.hpp"
 
@@ -103,7 +104,8 @@ void ConnectionManager::run() {
 
             if (h->is_timed_out()) {
                 Logger(LOG_GENERAL) << "[TIMEOUT] fd=" << h->fd();
-                ++it;
+                dynamic_cast<ConnectionHandler*>(h)->timeout_connection();
+                ++it;  // Increment before erasing the iterator
                 del(h);
             } else {
                 ++it;

--- a/src/ConnectionManager/ConnectionManager.cpp
+++ b/src/ConnectionManager/ConnectionManager.cpp
@@ -86,12 +86,10 @@ void ConnectionManager::run() {
             continue;
         }
 
-        // Commented to avoid spamming console/logs
-        // std::cout << "[EPOLL] woke up with " << fds << " events" << std::endl;
-
         for (int i = 0; i < fds; ++i) {
-            IHandler* h = (IHandler*)events[i].data.ptr;
-            // Keep or delete connection
+            IHandler* h = static_cast<IHandler*>(events[i].data.ptr);
+            Logger(LOG_GENERAL) << "[EPOLL] fd=" << h->fd() << " events=" << events[i].events;
+            // Keep or delete connection or listener
             bool keep = h->handle_event(*this, events[i].events);
             if (!keep) {
                 del(h);

--- a/src/ConnectionManager/Listener.cpp
+++ b/src/ConnectionManager/Listener.cpp
@@ -10,11 +10,13 @@
 #include "socket_utils.hpp"
 
 Listener::Listener(const ConfigServer* srv, int listen_fd) : _srv(srv), _fd(listen_fd) {}
+
 Listener::~Listener() {}
 
 int Listener::fd() const {
     return _fd;
 }
+
 uint32_t Listener::interests() const {
     return EPOLLIN;
 }

--- a/src/ConnectionManager/Response.cpp
+++ b/src/ConnectionManager/Response.cpp
@@ -85,6 +85,8 @@ static std::string code_to_string(HttpCode code) {
             return "Bad Request";
         case 405:
             return "Method Not Allowed";
+        case 408:
+            return "Connection timeout";
         case 411:
             return "Length Required";
         case 413:

--- a/src/ConnectionManager/Response.cpp
+++ b/src/ConnectionManager/Response.cpp
@@ -113,7 +113,6 @@ Response error_response(HttpCode code) {
     result.set_version(1, 1);
     result.set_code(code);
     result.set_response_string(code_to_string(code));
-    result.append_body(result.response_string());
     result.set_status(RES_ERROR);
 
     result.set_header("Content-Type", "text/plain");
@@ -121,6 +120,9 @@ Response error_response(HttpCode code) {
     stream << result.body().size();
     result.set_header("Content-Length", stream.str());
     result.set_header("Connection", "close");  // TODO Don't always close on errors
+
+    result.append_body(result.response_string());
+    result.append_body("\r\n");
 
     return result;
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -10,6 +10,6 @@ ConfigLocation::ConfigLocation()
     : allowed_methods(), autoindex(false), cgi(), index(), redirect(), root(), upload_store() {}
 
 ConfigServer::ConfigServer()
-    : client_max_body_size(0), error_page(), listen(), location(), timeout(0) {}
+    : client_max_body_size(0), error_page(), listen(), location(), timeout(10) {}
 
 Config::Config() : error_log(), server() {}


### PR DESCRIPTION
This PR makes it so that timing connections out issues a 408 Response, as per standard protocol.

# Other notable changes
- Refactored `ConnectionHandler::handle_event` to make it clearer and more straightforward. This is yet another preparation for the Request Processor.
- `error_response` now has a well-formed body (it was missing a carriage return).