### PR TITLE
Send generated bodies in multiple chunks

### DIFF
--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -1,6 +1,7 @@
 #ifndef RESPONSE_HPP
 #define RESPONSE_HPP
 
+#include <cstddef>
 #include <string>
 
 #include "HttpMessage.hpp"
@@ -24,12 +25,14 @@ public:
     const std::string& response_string() const;
     ResponseStatus     status() const;
     int                fd() const;
+    size_t             body_bytes_sent() const;
     bool               is_error() const;
 
     void set_code(HttpCode);
     void set_response_string(const std::string&);
     void set_status(ResponseStatus);
     void set_fd(int);
+    void set_body_bytes_sent(size_t);
 
     std::string serialize() const;
 
@@ -38,6 +41,7 @@ private:
     std::string    _response_string;
     ResponseStatus _status;
     int            _fd;
+    size_t         _body_bytes_sent;
 };
 
 Response error_response(HttpCode code);

--- a/src/ConnectionManager/Response.cpp
+++ b/src/ConnectionManager/Response.cpp
@@ -10,7 +10,13 @@
 #include "HttpMessage.hpp"
 #include "config.hpp"
 
-Response::Response() : HttpMessage(), _code(0), _response_string(), _status(RES_EMPTY), _fd(-1) {
+Response::Response()
+    : HttpMessage(),
+      _code(0),
+      _response_string(),
+      _status(RES_EMPTY),
+      _fd(-1),
+      _body_bytes_sent(0) {
     set_version(1, 1);
 }
 
@@ -18,7 +24,8 @@ Response::Response(const Response& other)
     : HttpMessage(other),
       _code(other._code),
       _response_string(other._response_string),
-      _status(other._status) {
+      _status(other._status),
+      _body_bytes_sent(other._body_bytes_sent) {
     _fd = dup(other.fd());
 }
 
@@ -30,7 +37,8 @@ const Response& Response::operator=(const Response& other) {
     _code = other._code;
     _response_string = other._response_string;
     _status = other._status;
-    
+    _body_bytes_sent = other._body_bytes_sent;
+
     if (_fd >= 0) close(_fd);
     _fd = dup(other.fd());
 
@@ -57,6 +65,10 @@ int Response::fd() const {
     return _fd;
 }
 
+size_t Response::body_bytes_sent() const {
+    return _body_bytes_sent;
+}
+
 /**
  * @brief Checks whether the Reponse has an HTTP status code denoting an error.
  * Such statuses must be between 400 and 599 inclusive.
@@ -80,6 +92,10 @@ void Response::set_status(ResponseStatus status) {
 
 void Response::set_fd(int fd) {
     _fd = fd;
+}
+
+void Response::set_body_bytes_sent(size_t body_bytes_sent) {
+    _body_bytes_sent = body_bytes_sent;
 }
 
 /**

--- a/src/RequestProcessor/send.cpp
+++ b/src/RequestProcessor/send.cpp
@@ -37,8 +37,14 @@ void Connection::queue_body_chunk() {
         }
         queue_write(std::string(buffer, static_cast<size_t>(read_bytes)));
     } else if (_response.body().empty() == false) {
-        queue_write(_response.body());  // TODO Don't send body in one chunk
+        const size_t start_bytes = _response.body_bytes_sent();
+        const size_t remaining_bytes = _response.body().size() - start_bytes;
+        const size_t chunk_size = SEND_SIZE < remaining_bytes ? SEND_SIZE : remaining_bytes;
+
+        queue_write(_response.body().substr(start_bytes, chunk_size));
+        _response.set_body_bytes_sent(start_bytes + chunk_size);
         Logger(LOG_DEBUG) << "[!] - Response sent!";
-        _response.set_status(RES_SENT);
+        if (_response.body().length() == _response.body_bytes_sent())
+            _response.set_status(RES_SENT);
     }
 }


### PR DESCRIPTION
This PR makes it so that the Request Processor sends generated bodies (like default error pages, directory listings etc) in multiple chunks instead of all at once.

This was fine when having SEND_SIZE set to large numbers like 1024, but dropping it lower to where it couldn't send the whole body in one go caused problems. This is now fixed.