### PR TITLE
Feat/request parsing error

### DIFF
--- a/include/Request.hpp
+++ b/include/Request.hpp
@@ -28,7 +28,7 @@ public:
     Request(const ConfigLocation* const, HttpMethod);
     ~Request();
 
-    const ConfigLocation& config() const;
+    const ConfigLocation* config() const;
     HttpMethod            method() const;
     RequestStatus         status() const;
     const std::string&    target() const;

--- a/include/Response.hpp
+++ b/include/Response.hpp
@@ -40,6 +40,6 @@ private:
     int            _fd;
 };
 
-Response error_response(HttpCode code);
+Response error_response(HttpCode, bool close);
 
 #endif

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -88,7 +88,7 @@ bool ConnectionHandler::is_timed_out() const {
  */
 void ConnectionHandler::timeout_connection() {
     Logger(LOG_DEBUG) << "[!] - Timing connection out!";
-    _conn.set_response(error_response(408));
+    _conn.set_response(error_response(408, true));
     _conn.queue_write(_conn.response().serialize());
     _conn.queue_write(_conn.response().body());
     _conn.send_data();
@@ -126,7 +126,7 @@ bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events
         _conn.process_request();
         log_response(response);
     } else if (request.status() == REQ_ERROR) {
-        _conn.set_response(error_response(request.error_status()));
+        _conn.set_response(error_response(request.error_status(), true));
     }
 
     // Send the response once it is ready

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -18,7 +18,7 @@ static void log_request(const Request& request) {
     Logger(LOG_DEBUG) << "Request Status:" << request.status();
     Logger(LOG_DEBUG) << "Method: " << request.method();
     Logger(LOG_DEBUG) << "Target: " << request.target();
-    Logger(LOG_DEBUG) << "Matched location: " << request.config().name;
+    if (request.config()) Logger(LOG_DEBUG) << "Matched location: " << request.config()->name;
     Logger(LOG_DEBUG) << "Body received: [" << request.body_received() << "]";
     Logger(LOG_DEBUG) << "Is body spooled: [" << request.is_body_spooled() << "]";
     if (request.is_body_spooled()) {

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 
 #include "ConnectionManager.hpp"
+#include "HttpMessage.hpp"
 #include "Logger.hpp"
 #include "Request.hpp"
 #include "Response.hpp"
@@ -140,9 +141,15 @@ bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events
 
     // Reset request and response objects once everything was sent
     if (response.status() == RES_SENT && _conn.has_pending_write() == false) {
+        bool                        must_close = false;
+        HttpMessage::HeaderIterator connection = response.header("Connection");
+        if (connection != response.headers_end() && connection->second == "close")
+            must_close = true;  // If "Connection: close", close connection after sending
+
         _conn.set_request(Request());
         _conn.set_response(Response());
         Logger(LOG_DEBUG) << "[!] - Reset request and response objects";
+        if (must_close) return false;
     }
 
     return true;

--- a/src/ConnectionManager/ConnectionManager.cpp
+++ b/src/ConnectionManager/ConnectionManager.cpp
@@ -92,7 +92,7 @@ void ConnectionManager::run() {
             Logger(LOG_GENERAL) << "[EPOLL] fd=" << h->fd() << " events=" << events[i].events;
             // Keep or delete connection or listener
             bool keep = h->handle_event(*this, events[i].events);
-            if (!keep) {
+            if (keep == false) {
                 del(h);
             } else {
                 // if interests() changed. IN/OUT

--- a/src/ConnectionManager/Request.cpp
+++ b/src/ConnectionManager/Request.cpp
@@ -90,8 +90,8 @@ Request::~Request() {
     }
 }
 
-const ConfigLocation& Request::config() const {
-    return *_config;
+const ConfigLocation* Request::config() const {
+    return _config;
 }
 
 HttpMethod Request::method() const {

--- a/src/ConnectionManager/Response.cpp
+++ b/src/ConnectionManager/Response.cpp
@@ -30,7 +30,7 @@ const Response& Response::operator=(const Response& other) {
     _code = other._code;
     _response_string = other._response_string;
     _status = other._status;
-    
+
     if (_fd >= 0) close(_fd);
     _fd = dup(other.fd());
 
@@ -136,7 +136,7 @@ static std::string code_to_string(HttpCode code) {
 /**
  * @brief Creates a Response object representing an error.
  */
-Response error_response(HttpCode code) {
+Response error_response(HttpCode code, bool close) {
     Response result;
 
     result.set_version(1, 1);
@@ -149,7 +149,9 @@ Response error_response(HttpCode code) {
     std::stringstream stream;
     stream << result.body().size();
     result.set_header("Content-Length", stream.str());
-    result.set_header("Connection", "close");  // TODO Don't always close on errors
-
+    if (close == true)
+        result.set_header("Connection", "close");
+    else
+        result.set_header("Connection", "keep-alive");
     return result;
 }

--- a/src/RequestProcessor/request_processor.cpp
+++ b/src/RequestProcessor/request_processor.cpp
@@ -19,10 +19,10 @@ ResponseStatus Connection::process_get_request(const FilePath& resource_path) {
             _response.set_code(200);
             _response.set_response_string("OK");
         } else {
-            _response = error_response(404);
+            _response = error_response(404, false);
         }
     } else if (!is_regular_file(path)) {  // We don't serve anything other than files or directories
-        _response = error_response(404);
+        _response = error_response(404, false);
     }
 
     // Fetch file on disk
@@ -31,13 +31,13 @@ ResponseStatus Connection::process_get_request(const FilePath& resource_path) {
         if (fd < 0) {
             Logger(LOG_ERROR) << "[process_request] - fetch_file" << strerror(errno);
             if (errno == EACCES)
-                _response = error_response(403);
+                _response = error_response(403, false);
             else if (errno == ENOENT)
-                _response = error_response(404);
+                _response = error_response(404, false);
             else if (errno == EINVAL || errno == ENAMETOOLONG) {
-                _response = error_response(400);
+                _response = error_response(400, false);
             } else
-                _response = error_response(500);
+                _response = error_response(500, false);
         } else {
             _response.set_fd(fd);
             _response.set_code(200);
@@ -74,7 +74,7 @@ ResponseStatus Connection::process_request() {
         case POST:
         case DELETE:
         default:
-            _response = error_response(501);
+            _response = error_response(501, false);
     }
 
     _request.set_status(REQ_PROCESSED);

--- a/src/RequestProcessor/request_processor.cpp
+++ b/src/RequestProcessor/request_processor.cpp
@@ -11,10 +11,10 @@ ResponseStatus Connection::process_get_request(const FilePath& resource_path) {
     FilePath path = resource_path;
 
     if (is_directory(path) == true) {
-        if (_request.config().index.empty() == false) {
+        if (_request.config()->index.empty() == false) {
             // Resource to fetch becomes the index file, not the folder itself
-            path = resource_path + "/" + _request.config().index;
-        } else if (_request.config().autoindex == true) {
+            path = resource_path + "/" + _request.config()->index;
+        } else if (_request.config()->autoindex == true) {
             _response.append_body(create_listing(path));
             _response.set_code(200);
             _response.set_response_string("OK");
@@ -62,10 +62,10 @@ ResponseStatus Connection::process_get_request(const FilePath& resource_path) {
 }
 
 ResponseStatus Connection::process_request() {
-    std::string relative_path = _request.target().substr(_request.config().name.length());
+    std::string relative_path = _request.target().substr(_request.config()->name.length());
     if (relative_path[0] == '/')  // If we still have a slash at the beginning, remove it
         relative_path.erase(0, relative_path.find_first_not_of('/'));
-    FilePath resource_path = resolve_path(relative_path, _request.config().root);
+    FilePath resource_path = resolve_path(relative_path, _request.config()->root);
 
     switch (_request.method()) {
         case GET:


### PR DESCRIPTION
This PR streamlines the connection closing process when having Response objects hold a `Connection: close` header.

First, the connection now is actually closed when the header is present (it wasn't the case before, we were doing more of a case by case thing which wasn't very intuitive).
Also, before this PR, all errors contained this header, closing the connection systematically. This is now more granular, only closing the connection when we can't really figure out where the current request ended. In practice, this translates to all Request Parser errors closing the connection, and Request Processor errors keeping it around.