### PR TITLE
FileMan: Fix and enhance create_listing

### DIFF
--- a/include/file_manager.hpp
+++ b/include/file_manager.hpp
@@ -29,7 +29,7 @@ ssize_t append_file(int, const std::string&);
 int     remove_file(const FilePath&);
 
 std::map<FilePath, Path_Type> get_dir_contents(const FilePath&);
-std::string                   create_listing(const FilePath&);
+std::string                   create_listing(const FilePath&, const std::string& target);
 
 std::string resolve_path(const FilePath& relative_path, const std::string& root);
 bool        is_under_directory(const FilePath& path, const FilePath& directory);

--- a/src/FileManager/listing.cpp
+++ b/src/FileManager/listing.cpp
@@ -59,25 +59,27 @@ std::map<FilePath, Path_Type> get_dir_contents(const FilePath& directory) {
 /**
  * @brief Creates an HTML listing of a directory, containing links to all entries inside.
  */
-// FIXME This is very broken (links aren't correct, and we shdouln't link the absolute path of
-// directories)
-std::string create_listing(const FilePath& directory) {
+std::string create_listing(const FilePath& directory, const std::string& target) {
     std::map<FilePath, Path_Type> entries = get_dir_contents(directory);
     std::stringstream             html_listing;
 
     html_listing << "<html>\n";
     html_listing << "<head>\n";
-    html_listing << "<title>" << directory << "</title>\n";
+    html_listing << "<title>" << target << "</title>\n";
     html_listing << "</head>\n";
     html_listing << "<body>\n";
-    html_listing << "<h1>Listing of " << directory << "</h1>\n";
+    html_listing << "<h1>Listing of " << target << "</h1>\n";
     html_listing << "<ul>\n";
     for (std::map<FilePath, Path_Type>::const_iterator e = entries.begin(); e != entries.end();
          ++e) {
         std::string path = e->first;
         if (e->second == DIR_PATH) path.append("/");
 
-        html_listing << "<li><a href=\"" << e->first << "\">" << path << "</a></li>\n";
+        if (e->first == ".")
+            html_listing << "<li><a href=\"" << target << "\">" << path << "</a></li>\n";
+        else
+            html_listing << "<li><a href=\"" << target << "/" << e->first << "\">" << path
+                         << "</a></li>\n";
     }
     html_listing << "</ul>\n";
     html_listing << "</body>\n";

--- a/src/RequestProcessor/request_processor.cpp
+++ b/src/RequestProcessor/request_processor.cpp
@@ -13,7 +13,7 @@ ResponseStatus Connection::process_get_request(const FilePath& resource_path) {
     if (is_directory(path) == true) {
         if (_request.config()->index.empty() == false) {
             // Resource to fetch becomes the index file, not the folder itself
-            path = resource_path + "/" + _request.config().index;
+            path = resource_path + "/" + _request.config()->index;
         } else if (_request.config()->autoindex == true) {
             _response.append_body(create_listing(path, _request.target()));
             _response.set_code(200);

--- a/src/RequestProcessor/request_processor.cpp
+++ b/src/RequestProcessor/request_processor.cpp
@@ -15,7 +15,7 @@ ResponseStatus Connection::process_get_request(const FilePath& resource_path) {
             // Resource to fetch becomes the index file, not the folder itself
             path = resource_path + "/" + _request.config().index;
         } else if (_request.config().autoindex == true) {
-            _response.append_body(create_listing(path));
+            _response.append_body(create_listing(path, _request.target()));
             _response.set_code(200);
             _response.set_response_string("OK");
         } else {


### PR DESCRIPTION
This function was pretty broken, notably in the links it was providing. This has been fixed to not only use relative links based on the request target instead of absolute, but also not display those absolute links. This is better since a real web server wouldn't leak it's file system architecture just like that; what's above a location's root is invisible to the users.