### PR TITLE
Feat/post rename tmp file

### DIFF
--- a/src/RequestParser/request_parser.cpp
+++ b/src/RequestParser/request_parser.cpp
@@ -174,7 +174,14 @@ RequestStatus Connection::resolve_location() {
         _request.set_error_status(404);
         _request.set_status(REQ_ERROR);
     } else {
-        _request.set_status(REQ_PARSED);
+        // TODO This check should go before the body arrives
+        if (_request.config()->allowed_methods.find(_request.method()) ==
+            _request.config()->allowed_methods.end()) {
+            _request.set_error_status(405);
+            _request.set_status(REQ_ERROR);
+        } else {
+            _request.set_status(REQ_PARSED);
+        }
     }
     return _request.status();
 }

--- a/src/RequestProcessor/post.cpp
+++ b/src/RequestProcessor/post.cpp
@@ -1,6 +1,7 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <cstdio>
 #include <cstring>
 
 #include "Connection.hpp"
@@ -27,14 +28,11 @@ void Connection::process_post_request(const FilePath& resource_path) {
         }
 
         if (_request.is_body_spooled() == true) {
-            // TODO we have access to std::rename, no need to copy a file
-            int fd = copy_file(_request.body_path(), resource_path);
-            if (fd < 0) {
-                Logger(LOG_ERROR) << "[process_post_request] - copy_file: " << strerror(errno);
+            if (std::rename(_request.body_path().c_str(), resource_path.c_str()) < 0) {
+                Logger(LOG_ERROR) << "[process_post_request] - rename: " << strerror(errno);
                 _response = error_response(500, false);
                 return;
             }
-            close(fd);
         } else {
             int fd = create_file(resource_path);
             if (fd < 0) {


### PR DESCRIPTION
This PR changes the POST request upload's behavior of copying the spool file: instead of copying, it now uses `std::rename` to move the file to its final location.

I know it should have been another PR, but I took the liberty of fixing a bug too: the request parser now checks incoming requests against the allowed functions list. You can't send a POST request to a location with only GET allowed anymore.