### PR TITLE
fix: Add 404 response case if target matches no upload store.

### DIFF
--- a/src/RequestProcessor/post.cpp
+++ b/src/RequestProcessor/post.cpp
@@ -51,5 +51,7 @@ void Connection::process_post_request(const FilePath& resource_path) {
         _response.set_code(200);  // TODO return 30x See Other response
         _response.set_response_string("OK");
         _response.set_header("Content-Length", "0");
+    } else {
+        _response = error_response(404, true);
     }
 }


### PR DESCRIPTION
Crash occurs when uploading to a folder that doesn't have an upload store. I guess POST requests only do things when there's an upload store or cgi.

If i POST to `/test`, which isn't a valid location, it will resolve back to `/`. Currently on main, the request processor will do this with it :
```
if (cgi && resource path is okay)
    // cgi...
else if (upload store isn't empty)
    // post...
else
    // nothing, _code stays at 0 and assertion crashes on serialization.
```

This PR fixes it by setting a 404 response. In case the config file allows for POST on `/` without an upload store