### PR TITLE
CGI: Make CgiHandler constructor take a CgiProcess reference

### DIFF
--- a/include/CgiHandler.hpp
+++ b/include/CgiHandler.hpp
@@ -7,13 +7,14 @@
 #include <string>
 
 #include "IHandler.hpp"
+#include "cgi.hpp"
 
 class ConnectionHandler;
 class ConnectionManager;
 
 class CgiHandler : public IHandler {
 public:
-    CgiHandler(pid_t pid, int stdout_fd, int stderr_fd, long timeout, ConnectionHandler* client);
+    CgiHandler(const CgiProcess&, long timeout, ConnectionHandler* client);
 
     virtual ~CgiHandler();
 

--- a/src/Cgi/CgiHandler.cpp
+++ b/src/Cgi/CgiHandler.cpp
@@ -12,12 +12,10 @@
 #include "Logger.hpp"
 #include "cgi.hpp"
 
-// TODO This could take a CgiProcess reference to need less arguments
-CgiHandler::CgiHandler(pid_t pid, int stdout_fd, int stderr_fd, long timeout,
-                       ConnectionHandler* client)
-    : _pid(pid),
-      _stdout_fd(stdout_fd),
-      _stderr_fd(stderr_fd),
+CgiHandler::CgiHandler(const CgiProcess& process, long timeout, ConnectionHandler* client)
+    : _pid(process.pid),
+      _stdout_fd(process.stdout_fd),
+      _stderr_fd(process.stderr_fd),
       _timeout(timeout),
       _start(std::time(NULL)),
       _client(client),

--- a/src/Cgi/cgi_start.cpp
+++ b/src/Cgi/cgi_start.cpp
@@ -73,8 +73,6 @@ CgiRequest build_cgi_request(const std::string& relative_path, const Request& re
 CgiProcess start_cgi(const CgiRequest& req) {
     CgiPipes pipes;
 
-    // TODO Instead of returning a CgiProcess in a specific state to signify errors, throw an
-    // exception
     if (!init_pipes(pipes)) return make_failed_process();
 
     pid_t pid = fork();

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -176,8 +176,8 @@ bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events
         _conn.process_request();
         if (_conn.has_pending_cgi()) {
             CgiProcess  process = _conn.grab_pending_cgi();
-            CgiHandler* handler = new CgiHandler(process.pid, process.stdout_fd, process.stderr_fd,
-                                                 static_cast<long>(_conn.config()->timeout), this);
+            CgiHandler* handler =
+                new CgiHandler(process, static_cast<long>(_conn.config()->timeout), this);
 
             manager.add(handler);
             _cgi_handler = handler;


### PR DESCRIPTION
This was because we were using CgiProcess values to construct a CgiHandler, instead of passing the CgiProcess directly.