### PR TITLE
CGI: Abort CGI when destroying a CgiHandler

### DIFF
--- a/src/Cgi/CgiHandler.cpp
+++ b/src/Cgi/CgiHandler.cpp
@@ -33,7 +33,7 @@ CgiHandler::~CgiHandler() {
         close(_stderr_fd);
         _stderr_fd = -1;
     }
-    // TODO Kill process with kill?
+    abort_cgi();
     Logger(LOG_DEBUG) << "[CGI] Handler destroyed for pid " << _pid;
 }
 

--- a/src/Cgi/CgiHandler.cpp
+++ b/src/Cgi/CgiHandler.cpp
@@ -49,9 +49,8 @@ uint32_t CgiHandler::interests() const {
  * @brief If the CgiHandler is currently holding a process, this function kills and reaps it.
  */
 void CgiHandler::abort_cgi() {
-    Logger(LOG_ERROR) << "[CGI] abort";
-
     if (_pid > 0) {
+        Logger(LOG_ERROR) << "[CGI] abort";
         kill(_pid, SIGKILL);
         waitpid(_pid, NULL, 0);
         _pid = -1;


### PR DESCRIPTION
This way, cleanup is complete when destroying a CgiHandler.

@0yech Not sure about this one, is this potentially breaking? If not, I think the added safety is always good.