### PR TITLE
Feat/redirections

### DIFF
--- a/config/1.conf
+++ b/config/1.conf
@@ -35,7 +35,7 @@ server {
         autoindex on;
     }
 
-    location /this/is/root/ {
+    location /this/is/root {
         allowed_methods GET;
 
         # Redirect all queries to /this/is/root/ to the root location

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -28,10 +28,10 @@ typedef struct ConfigLocation {
     bool                            autoindex;
     std::map<std::string, FilePath> cgi;  // Bind an extension to an interpreter
     // File to serve when requesting a directory (relative from the requested file)
-    std::string                     index;
-    std::map<HttpCode, std::string> redirect;  // Redirect to a URL using a specific HTTP code
-    FilePath                        root;
-    FilePath                        upload_store;
+    std::string                      index;
+    std::pair<HttpCode, std::string> redirect;  // Redirect to a URL using a specific HTTP code
+    FilePath                         root;
+    FilePath                         upload_store;
 } ConfigLocation;
 
 typedef struct ConfigServer {

--- a/src/ConfigParser/config_parser.cpp
+++ b/src/ConfigParser/config_parser.cpp
@@ -106,12 +106,10 @@ static void check_config(const Config& config) {
             for (CgiIterator j = l->second.cgi.begin(); j != l->second.cgi.end(); ++j) {
                 if (is_regular_file(j->second) == false) throw ParserError("Invalid cgi directive");
             }
-            for (ErrorPageIterator r = l->second.redirect.begin(); r != l->second.redirect.end();
-                 ++r) {
-                // Redirection have to use a 3XX code
-                if (r->first < 300 || r->first > 399)
-                    throw ParserError("Invalid redirect directive");
-            }
+            // Redirection have to use a 3XX code
+            if (l->second.redirect.first != 0 &&
+                (l->second.redirect.first < 300 || l->second.redirect.first > 399))
+                throw ParserError("Invalid redirect directive");
             if (l->second.root.empty() == false && is_directory(l->second.root) == false)
                 throw ParserError("Invalid root directive");
             if (l->second.upload_store.empty() == false &&
@@ -140,7 +138,7 @@ Config parse_file(std::ifstream& file) {
             throw ParserError("Missing location directive in server context");
         } else {
             for (LocationIterator i = s->location.begin(); i != s->location.end(); ++i) {
-                if (i->second.root.empty() && i->second.redirect.empty()) {
+                if (i->second.root.empty() && i->second.redirect.first == 0) {
                     throw ParserError("Missing root directive in location context");
                 }
             }
@@ -368,7 +366,7 @@ ConfigLocation parse_location(TokenIterator* t, TokenIterator end) {
                 if (check_string(tokens[1].word, "1234567890") == false)
                     throw ParserError(tokens[1], "Wrong redirection code syntax");
                 HttpCode code = static_cast<HttpCode>(std::atol(tokens[1].word.c_str()));
-                config.redirect.insert(std::pair<HttpCode, std::string>(code, tokens[2].word));
+                config.redirect = std::pair<HttpCode, std::string>(code, tokens[2].word);
             } else if (directive == "root") {
                 if (tokens.size() != 3)
                     throw ParserError(tokens[0], "Wrong number of tokens in root directive");

--- a/src/RequestProcessor/request_processor.cpp
+++ b/src/RequestProcessor/request_processor.cpp
@@ -9,6 +9,17 @@
 #include "config.hpp"
 
 void Connection::process_request() {
+    // TODO Redirection checking should probably happen before the body arrives
+    if (_request.config()->redirect.first >= 300 && _request.config()->redirect.first <= 399) {
+        _response.set_code(301);
+        _response.set_response_string("Moved Permanently");
+        _response.set_header("Content-Type", "text/html");
+        _response.set_header("Content-Length", "0");
+        _request.set_status(REQ_PROCESSED);
+        // TODO Add Location header pointing to the right resource
+        return;
+    }
+
     std::string relative_path = _request.target().substr(_request.config()->name.length());
     if (!relative_path.empty() &&  // If we still have a slash at the beginning, remove it
         relative_path[0] == '/')

--- a/src/RequestProcessor/request_processor.cpp
+++ b/src/RequestProcessor/request_processor.cpp
@@ -9,21 +9,26 @@
 #include "config.hpp"
 
 void Connection::process_request() {
+    std::string relative_path = _request.target().substr(_request.config()->name.length());
+    if (!relative_path.empty() &&  // If we still have a slash at the beginning, remove it
+        relative_path[0] == '/')
+        relative_path.erase(0, relative_path.find_first_not_of('/'));
+
     // TODO Redirection checking should probably happen before the body arrives
     if (_request.config()->redirect.first >= 300 && _request.config()->redirect.first <= 399) {
         _response.set_code(301);
         _response.set_response_string("Moved Permanently");
         _response.set_header("Content-Type", "text/html");
         _response.set_header("Content-Length", "0");
+
+        const std::string& location_name = _request.config()->redirect.second;
+        if (location_name == "/")
+            _response.set_header("Location", location_name + relative_path);
+        else
+            _response.set_header("Location", location_name + "/" + relative_path);
         _request.set_status(REQ_PROCESSED);
-        // TODO Add Location header pointing to the right resource
         return;
     }
-
-    std::string relative_path = _request.target().substr(_request.config()->name.length());
-    if (!relative_path.empty() &&  // If we still have a slash at the beginning, remove it
-        relative_path[0] == '/')
-        relative_path.erase(0, relative_path.find_first_not_of('/'));
 
     switch (_request.method()) {
         case GET:


### PR DESCRIPTION
Adds HTTP 301 redirections to requests to location with a `redirect` directive.

# Example
## Configuration
```
    location /this/is/root {
        allowed_methods GET;

        # Redirect all queries to /this/is/root/ to the root location
        redirect 301 /;
    }
```
## HTTP Transaction
```
> GET /this/is/root/index.html HTTP/1.1
> Host: 127.0.0.1:8080
> User-Agent: curl/8.5.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Content-Length: 0
< Content-Type: text/html
< Location: /index.html
```