### PR TITLE
Bug/case insensitive headers

### DIFF
--- a/include/request_parser.hpp
+++ b/include/request_parser.hpp
@@ -8,6 +8,7 @@
 
 // helpers.cpp
 
+std::string              to_lowercase(const std::string&);
 std::string              extract_query_string(const std::string& target);
 std::string              trim(const std::string&);
 std::vector<std::string> split_header_values(const std::string&);

--- a/src/Cgi/cgi_start.cpp
+++ b/src/Cgi/cgi_start.cpp
@@ -38,8 +38,8 @@ CgiRequest build_cgi_request(const std::string& relative_path, const Request& re
     cgi.method = method_to_string(request.method());                           // GET
     cgi.query_string = request.query_string();                                 // hello=world
 
-    if (request.has_header("Content-Type"))
-        cgi.content_type = request.header("Content-Type")->second;
+    if (request.has_header("content-type"))
+        cgi.content_type = request.header("content-type")->second;
     else
         cgi.content_type = "";
 

--- a/src/ConnectionManager/Connection.cpp
+++ b/src/ConnectionManager/Connection.cpp
@@ -91,8 +91,8 @@ ssize_t Connection::receive_data() {
 bool Connection::handle_content_length_header(Request& request) {
     size_t content_length = 0;
 
-    if (request.has_header("Content-Length") &&
-        !parse_content_length_value(request.header("Content-Length")->second, content_length)) {
+    if (request.has_header("content-length") &&
+        !parse_content_length_value(request.header("content-length")->second, content_length)) {
         request.set_error_status(400);
         request.set_status(REQ_ERROR);
         return false;

--- a/src/RequestParser/helpers.cpp
+++ b/src/RequestParser/helpers.cpp
@@ -1,13 +1,29 @@
+#include <cctype>
 #include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "Request.hpp"
+#include "request_parser.hpp"
+
+/**
+ * @brief Returns a new string with every character put to lowercase.
+ */
+std::string to_lowercase(const std::string& string) {
+    std::string lowercased = string;
+
+    for (size_t i = 0; i < lowercased.size(); ++i) {
+        if (std::isupper(lowercased[i])) {
+            lowercased[i] = static_cast<char>(std::tolower(lowercased[i]));
+        }
+    }
+
+    return lowercased;
+}
 
 /**
  * @brief Minimal implementation to fetch the query string from the target.
- * /over/there?name=ferret
  */
 std::string extract_query_string(const std::string& target) {
     size_t pos = target.find('?');

--- a/src/RequestParser/request_parser.cpp
+++ b/src/RequestParser/request_parser.cpp
@@ -79,10 +79,10 @@ RequestStatus Connection::parse_headers() {
         }
 
         std::vector<std::string> parsed_values;
-        std::string              key = trim(line.substr(0, colon));
+        std::string              key = to_lowercase(trim(line.substr(0, colon)));
         std::string              value = trim(line.substr(colon + 1));
         // Not all headers must be split
-        if (key == "Set-Cookie")
+        if (key == "set-cookie")
             parsed_values.push_back(value);
         else
             parsed_values = split_header_values(value);
@@ -100,7 +100,7 @@ RequestStatus Connection::parse_headers() {
     _read_index += 2;
 
     // Check for mandatory Host header, and if it is unique.
-    if (!_request.has_header("Host") || !is_header_unique(_request, "Host")) {
+    if (!_request.has_header("host") || !is_header_unique(_request, "host")) {
         _request.set_error_status(400);
         _request.set_status(REQ_ERROR);
         return _request.status();


### PR DESCRIPTION
This PR makes it so that the Request Parser lowercases all incoming request headers, in order to process them regardless of case inside of their names.