### PR TITLE
Bug/location resolution before body

### DIFF
--- a/include/Connection.hpp
+++ b/include/Connection.hpp
@@ -43,7 +43,6 @@ private:
     void shrink_read_buffer();
 
     RequestStatus parse_request_line();
-    bool          handle_content_length_header(Request& request);
     RequestStatus parse_headers();
     RequestStatus parse_body();
     RequestStatus resolve_location();

--- a/include/Connection.hpp
+++ b/include/Connection.hpp
@@ -32,7 +32,6 @@ public:
     void                set_response(const Response&);
     void                queue_write(const std::string& data);
     bool                has_pending_write() const;
-    bool                handle_content_length_header(Request& request);
     bool                has_pending_cgi() const;
     CgiProcess          grab_pending_cgi();
     const ConfigServer* config() const;
@@ -44,6 +43,7 @@ private:
     void shrink_read_buffer();
 
     RequestStatus parse_request_line();
+    bool          handle_content_length_header(Request& request);
     RequestStatus parse_headers();
     RequestStatus parse_body();
     RequestStatus resolve_location();

--- a/include/request_parser.hpp
+++ b/include/request_parser.hpp
@@ -13,7 +13,6 @@ std::string              extract_query_string(const std::string& target);
 std::string              trim(const std::string&);
 std::vector<std::string> split_header_values(const std::string&);
 bool                     parse_content_length_value(const std::string& value, size_t& out);
-bool                     handle_content_length_header(Request& request);
 bool                     is_header_unique(Request& request, const std::string& key);
 
 #endif  // REQUEST_PARSER_HPP

--- a/src/ConnectionManager/Connection.cpp
+++ b/src/ConnectionManager/Connection.cpp
@@ -11,7 +11,6 @@
 #include "Request.hpp"
 #include "Response.hpp"
 #include "config.hpp"
-#include "request_parser.hpp"
 
 Connection::Connection(const ConfigServer* const config, int socket)
     : _config(config),
@@ -86,28 +85,6 @@ ssize_t Connection::receive_data() {
     }
 
     return total;
-}
-
-bool Connection::handle_content_length_header(Request& request) {
-    size_t content_length = 0;
-
-    if (request.has_header("content-length") &&
-        !parse_content_length_value(request.header("content-length")->second, content_length)) {
-        request.set_error_status(400);
-        request.set_status(REQ_ERROR);
-        return false;
-    }
-    request.set_content_length(content_length);
-    if (content_length > _config->client_max_body_size) {
-        request.set_error_status(413);
-        request.set_status(REQ_ERROR);
-        return false;
-    }
-    if (content_length > 0) {
-        request.set_status(REQ_HEADERS);
-        return false;
-    }
-    return true;
 }
 
 bool Connection::has_pending_cgi() const {

--- a/src/RequestParser/request_parser.cpp
+++ b/src/RequestParser/request_parser.cpp
@@ -67,11 +67,19 @@ RequestStatus Connection::parse_request_line() {
     return _request.status();
 }
 
+/**
+ * @brief This function extracts the Content-Length value from a Request's headers and puts inside
+ * of the appropriate value in the same Request.
+ *
+ * @return true if a Content-Length was successfully extracted, false if an error occured or no
+ * Content-Length header exists.
+ */
 static bool handle_content_length_header(Request& request, const size_t client_max_body_size) {
+    assert(request.has_header("Content-Length"));
     size_t content_length = 0;
 
-    if (request.has_header("Content-Length") &&
-        !parse_content_length_value(request.header("Content-Length")->second, content_length)) {
+    if (parse_content_length_value(request.header("Content-Length")->second, content_length) ==
+        false) {
         request.set_error_status(400);
         request.set_status(REQ_ERROR);
         return false;
@@ -136,8 +144,11 @@ RequestStatus Connection::parse_headers() {
         return _request.status();
     }
 
-    if (!handle_content_length_header(_request, _config->client_max_body_size))
-        return _request.status();
+    if (_request.has_header("Content-Length") &&
+        handle_content_length_header(_request, _config->client_max_body_size) == false) {
+        return _request.status();  // Either an error occured, or no Content-Length was found
+    }
+
     _request.set_status(REQ_BODY);
     return _request.status();
 }

--- a/src/RequestParser/request_parser.cpp
+++ b/src/RequestParser/request_parser.cpp
@@ -68,13 +68,11 @@ RequestStatus Connection::parse_request_line() {
 }
 
 /**
- * @brief This function extracts the Content-Length value from a Request's headers and puts inside
- * of the appropriate value in the same Request.
- *
- * @return true if a Content-Length was successfully extracted, false if an error occured or no
- * Content-Length header exists.
+ * @brief This function extracts the Content-Length value from a Request's headers and puts it
+ * inside of the appropriate value in the same Request.
+ * It also sets the Request status approperiately, either to signify an error, or to indicate that a
  */
-static bool handle_content_length_header(Request& request, const size_t client_max_body_size) {
+static void handle_content_length_header(Request& request, const size_t client_max_body_size) {
     assert(request.has_header("Content-Length"));
     size_t content_length = 0;
 
@@ -82,19 +80,17 @@ static bool handle_content_length_header(Request& request, const size_t client_m
         false) {
         request.set_error_status(400);
         request.set_status(REQ_ERROR);
-        return false;
+        return;
     }
     request.set_content_length(content_length);
     if (content_length > client_max_body_size) {
         request.set_error_status(413);
         request.set_status(REQ_ERROR);
-        return false;
+        return;
     }
     if (content_length > 0) {
         request.set_status(REQ_HEADERS);
-        return false;
     }
-    return true;
 }
 
 RequestStatus Connection::parse_headers() {
@@ -144,11 +140,13 @@ RequestStatus Connection::parse_headers() {
         return _request.status();
     }
 
-    if (_request.has_header("Content-Length") &&
-        handle_content_length_header(_request, _config->client_max_body_size) == false) {
-        return _request.status();  // Either an error occured, or no Content-Length was found
+    if (_request.has_header("Content-Length")) {
+        handle_content_length_header(_request, _config->client_max_body_size);
+        if (_request.status() == REQ_ERROR || _request.status() == REQ_HEADERS)
+            return _request.status();  // An error or a valid Content-Length
     }
 
+    // No Content-Length, so no body to be parsed
     _request.set_status(REQ_BODY);
     return _request.status();
 }

--- a/src/RequestParser/request_parser.cpp
+++ b/src/RequestParser/request_parser.cpp
@@ -67,6 +67,28 @@ RequestStatus Connection::parse_request_line() {
     return _request.status();
 }
 
+bool Connection::handle_content_length_header(Request& request) {
+    size_t content_length = 0;
+
+    if (request.has_header("Content-Length") &&
+        !parse_content_length_value(request.header("Content-Length")->second, content_length)) {
+        request.set_error_status(400);
+        request.set_status(REQ_ERROR);
+        return false;
+    }
+    request.set_content_length(content_length);
+    if (content_length > _config->client_max_body_size) {
+        request.set_error_status(413);
+        request.set_status(REQ_ERROR);
+        return false;
+    }
+    if (content_length > 0) {
+        request.set_status(REQ_HEADERS);
+        return false;
+    }
+    return true;
+}
+
 RequestStatus Connection::parse_headers() {
     assert(_request.status() == REQ_REQUEST_LINE);
 

--- a/src/RequestParser/request_parser.cpp
+++ b/src/RequestParser/request_parser.cpp
@@ -151,6 +151,50 @@ RequestStatus Connection::parse_headers() {
     return _request.status();
 }
 
+/**
+ * @brief Resolves which location config should be assigned to the given request, based on its
+ * target.
+ * It resolves in order, but the most precise location found will be set.
+ * For example, if the target of the request is /images, but there are / and /images locations in
+ * the configuration, the /images location will be choosen, even though / comes before
+ * alphabetically.
+ */
+// TODO This function resolves to a location when a file's name starts with that location name
+// For example, with location /upload configured, getting /upload.html resolves to /upload, but
+// shouldn't To fix this, we should base ourself on whether the full location "/upload/" with the
+// last / included is present in the request's target
+RequestStatus Connection::resolve_location() {
+    assert(_request.status() == REQ_HEADERS || _request.status() == REQ_BODY);
+
+    const std::string& request_target = _request.target();
+    bool               matched = false;
+
+    for (LocationIterator l = _config->location.begin(); l != _config->location.end(); ++l) {
+        const std::string& location_name = l->first;
+        const size_t       location_length = location_name.length();
+
+        // If the target matches a location, even just as a prefix, then it's the right location
+        if (request_target.substr(0, location_length) == location_name) {
+            _request.set_config(&l->second);
+            matched = true;
+        }
+    }
+
+    if (!matched) {
+        _request.set_error_status(404);
+        _request.set_status(REQ_ERROR);
+    } else {
+        if (_request.config()->allowed_methods.find(_request.method()) ==
+            _request.config()->allowed_methods.end()) {
+            _request.set_error_status(405);
+            _request.set_status(REQ_ERROR);
+        } else {
+            _request.set_status(REQ_PARSED);
+        }
+    }
+    return _request.status();
+}
+
 RequestStatus Connection::parse_body() {
     assert(_request.status() == REQ_HEADERS);
 
@@ -182,59 +226,14 @@ RequestStatus Connection::parse_body() {
     return _request.status();
 }
 
-/**
- * @brief Resolves which location config should be assigned to the given request, based on its
- * target.
- * It resolves in order, but the most precise location found will be set.
- * For example, if the target of the request is /images, but there are / and /images locations in
- * the configuration, the /images location will be choosen, even though / comes before
- * alphabetically.
- */
-// TODO This function resolves to a location when a file's name starts with that location name
-// For example, with location /upload configured, getting /upload.html resolves to /upload, but
-// shouldn't To fix this, we should base ourself on whether the full location "/upload/" with the
-// last / included is present in the request's target
-RequestStatus Connection::resolve_location() {
-    assert(_request.status() == REQ_BODY);
-
-    const std::string& request_target = _request.target();
-    bool               matched = false;
-
-    for (LocationIterator l = _config->location.begin(); l != _config->location.end(); ++l) {
-        const std::string& location_name = l->first;
-        const size_t       location_length = location_name.length();
-
-        // If the target matches a location, even just as a prefix, then it's the right location
-        if (request_target.substr(0, location_length) == location_name) {
-            _request.set_config(&l->second);
-            matched = true;
-        }
-    }
-
-    if (!matched) {
-        _request.set_error_status(404);
-        _request.set_status(REQ_ERROR);
-    } else {
-        // TODO This check should go before the body arrives
-        if (_request.config()->allowed_methods.find(_request.method()) ==
-            _request.config()->allowed_methods.end()) {
-            _request.set_error_status(405);
-            _request.set_status(REQ_ERROR);
-        } else {
-            _request.set_status(REQ_PARSED);
-        }
-    }
-    return _request.status();
-}
-
 RequestStatus Connection::parse_request() {
     if (_request.status() == REQ_EMPTY) parse_request_line();
 
     if (_request.status() == REQ_REQUEST_LINE) parse_headers();
 
-    if (_request.status() == REQ_HEADERS) parse_body();
+    if (_request.status() == REQ_HEADERS || _request.status() == REQ_BODY) resolve_location();
 
-    if (_request.status() == REQ_BODY) resolve_location();
+    if (_request.status() == REQ_HEADERS) parse_body();
 
     shrink_read_buffer();
     return _request.status();

--- a/src/RequestParser/request_parser.cpp
+++ b/src/RequestParser/request_parser.cpp
@@ -67,7 +67,7 @@ RequestStatus Connection::parse_request_line() {
     return _request.status();
 }
 
-bool Connection::handle_content_length_header(Request& request) {
+static bool handle_content_length_header(Request& request, const size_t client_max_body_size) {
     size_t content_length = 0;
 
     if (request.has_header("Content-Length") &&
@@ -77,7 +77,7 @@ bool Connection::handle_content_length_header(Request& request) {
         return false;
     }
     request.set_content_length(content_length);
-    if (content_length > _config->client_max_body_size) {
+    if (content_length > client_max_body_size) {
         request.set_error_status(413);
         request.set_status(REQ_ERROR);
         return false;
@@ -136,7 +136,8 @@ RequestStatus Connection::parse_headers() {
         return _request.status();
     }
 
-    if (!handle_content_length_header(_request)) return _request.status();
+    if (!handle_content_length_header(_request, _config->client_max_body_size))
+        return _request.status();
     _request.set_status(REQ_BODY);
     return _request.status();
 }


### PR DESCRIPTION
This PR makes the location resolution for an incoming request happen **before the body of the request gets parsed**.

This enhances performance by allowing the server to reject requests to nonexistent locations before the body gets read.