### PR TITLE
feat: Added rewritten chunked encoding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ CFILES		=	$(SRCDIR)/main.cpp \
 				$(SRCDIR)/ConnectionManager/Listener.cpp \
 				$(SRCDIR)/ConnectionManager/Request.cpp \
 				$(SRCDIR)/ConnectionManager/Response.cpp \
+				$(SRCDIR)/ConnectionManager/ChunkedEncoding.cpp \
 				$(SRCDIR)/helpers/socket.cpp \
 				$(SRCDIR)/helpers/getcwd.cpp \
 				$(SRCDIR)/FileManager/helpers.cpp \

--- a/include/Connection.hpp
+++ b/include/Connection.hpp
@@ -31,6 +31,7 @@ public:
     void                set_request(const Request&);
     void                set_response(const Response&);
     void                queue_write(const std::string& data);
+    bool                handle_chunked_encoding_header(Request& request);
     bool                has_pending_write() const;
     bool                has_pending_cgi() const;
     CgiProcess          grab_pending_cgi();
@@ -45,6 +46,7 @@ private:
     RequestStatus parse_request_line();
     RequestStatus parse_headers();
     RequestStatus parse_body();
+    RequestStatus parse_chunked_body();
     RequestStatus resolve_location();
 
     void process_get_request(const std::string& relative_path);
@@ -58,10 +60,16 @@ private:
 
     int _socket;
 
+    // Parse via Content-Length
     std::string _read_buffer;
     size_t      _read_index;
     std::string _write_buffer;
     size_t      _write_index;
+
+    // Parse via Chunked Encoding
+    bool   _is_chunked;
+    size_t _chunk_size;
+    size_t _chunk_received;
 
     // Set by post requests when a CGI is launched
     CgiProcess _pending_cgi_process;

--- a/include/request_parser.hpp
+++ b/include/request_parser.hpp
@@ -13,6 +13,7 @@ std::string              extract_query_string(const std::string& target);
 std::string              trim(const std::string&);
 std::vector<std::string> split_header_values(const std::string&);
 bool                     parse_content_length_value(const std::string& value, size_t& out);
+bool                     parse_chunk_size(const std::string& str, size_t& out);
 bool                     is_header_unique(Request& request, const std::string& key);
 
 #endif  // REQUEST_PARSER_HPP

--- a/src/ConnectionManager/ChunkedEncoding.cpp
+++ b/src/ConnectionManager/ChunkedEncoding.cpp
@@ -1,14 +1,13 @@
-#include "Connection.hpp"
-
 #include <sys/socket.h>
 #include <sys/types.h>
 
 #include <cassert>
 #include <cerrno>
 #include <cstring>
-
-#include "Request.hpp"
 #include <request_parser.hpp>
+
+#include "Connection.hpp"
+#include "Request.hpp"
 
 bool parse_chunk_size(const std::string& str, size_t& out) {
     if (str.empty()) return false;

--- a/src/ConnectionManager/ChunkedEncoding.cpp
+++ b/src/ConnectionManager/ChunkedEncoding.cpp
@@ -1,0 +1,144 @@
+#include "Connection.hpp"
+
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <cassert>
+#include <cerrno>
+#include <cstring>
+
+#include "Request.hpp"
+#include <request_parser.hpp>
+
+bool parse_chunk_size(const std::string& str, size_t& out) {
+    if (str.empty()) return false;
+
+    size_t value = 0;
+
+    for (size_t i = 0; i < str.size(); ++i) {
+        int digit;
+
+        if (str[i] >= '0' && str[i] <= '9')
+            digit = str[i] - '0';
+        else if (str[i] >= 'a' && str[i] <= 'f')
+            digit = str[i] - 'a' + 10;
+        else if (str[i] >= 'A' && str[i] <= 'F')
+            digit = str[i] - 'A' + 10;
+        else
+            return false;
+
+        value = value * 16 + static_cast<size_t>(digit);
+    }
+
+    out = value;
+    return true;
+}
+
+bool Connection::handle_chunked_encoding_header(Request& request) {
+    _is_chunked = false;
+    _chunk_size = 0;
+    _chunk_received = 0;
+
+    bool has_transfer_encoding = false;
+    bool has_chunked = false;
+
+    for (HttpMessage::HeaderIterator it = request.headers_begin(); it != request.headers_end();
+         ++it) {
+        if (it->first != "transfer-encoding") continue;
+
+        has_transfer_encoding = true;
+
+        if (trim(it->second) == "chunked") has_chunked = true;
+    }
+
+    if (!has_transfer_encoding) return true;
+
+    if (!has_chunked) {
+        request.set_error_status(400);
+        request.set_status(REQ_ERROR);
+        return false;
+    }
+
+    if (request.has_header("content-length")) {
+        request.set_error_status(400);
+        request.set_status(REQ_ERROR);
+        return false;
+    }
+
+    _is_chunked = true;
+    _chunk_size = 0;
+    _chunk_received = 0;
+
+    request.set_status(REQ_HEADERS);
+    return false;
+}
+
+RequestStatus Connection::parse_chunked_body() {
+    while (_read_index < _read_buffer.size()) {
+        if (_chunk_size == 0 && _chunk_received == 0) {
+            size_t line_end = _read_buffer.find("\r\n", _read_index);  // get line from read buffer
+            if (line_end == std::string::npos) return _request.status();
+
+            std::string line =
+                _read_buffer.substr(_read_index, line_end - _read_index);  // Extract size line
+
+            size_t semi = line.find(';');
+            if (semi != std::string::npos) line = line.substr(0, semi);  // cut chunk extension
+
+            if (!parse_chunk_size(trim(line), _chunk_size)) {  // trim spaces
+                _request.set_error_status(400);
+                _request.set_status(REQ_ERROR);
+                return _request.status();
+            }
+
+            _read_index = line_end + 2;  // jump past \r\n
+
+            if (_chunk_size == 0) {  // End of chunked request
+                if (_read_buffer.size() - _read_index < 2)
+                    return _request.status();  // in case read buffer doesn't reach the end
+
+                if (_read_buffer[_read_index] != '\r' || _read_buffer[_read_index + 1] != '\n') {
+                    _request.set_error_status(400);
+                    _request.set_status(REQ_ERROR);
+                    return _request.status();
+                }
+
+                _read_index += 2;
+                _request.set_content_length(_request.body_received());
+                _request.set_status(REQ_PARSED);  // Chunked request parsed
+                return _request.status();
+            }
+        }
+
+        size_t remaining = _chunk_size - _chunk_received;
+        size_t available = _read_buffer.size() - _read_index;
+        size_t chunk = std::min(remaining, available);
+
+        if (chunk == 0) return _request.status();
+
+        if (!_request.append_body_chunk(_read_buffer.data() + _read_index, chunk)) {
+            _request.set_error_status(500);
+            _request.set_status(REQ_ERROR);
+            return _request.status();
+        }
+
+        _read_index += chunk;
+        _chunk_received += chunk;
+
+        if (_chunk_received == _chunk_size) {
+            if (_read_buffer.size() - _read_index < 2) return _request.status();
+
+            if (_read_buffer[_read_index] != '\r' || _read_buffer[_read_index + 1] != '\n') {
+                _request.set_error_status(400);
+                _request.set_status(REQ_ERROR);
+                return _request.status();
+            }
+
+            _read_index += 2;
+            _chunk_size = 0;
+            _chunk_received = 0;
+        }
+    }
+
+    return _request.status();
+}

--- a/src/ConnectionManager/ChunkedEncoding.cpp
+++ b/src/ConnectionManager/ChunkedEncoding.cpp
@@ -41,13 +41,11 @@ bool Connection::handle_chunked_encoding_header(Request& request) {
     bool has_transfer_encoding = false;
     bool has_chunked = false;
 
-    for (HttpMessage::HeaderIterator it = request.headers_begin(); it != request.headers_end();
-         ++it) {
-        if (it->first != "transfer-encoding") continue;
-
+    if (request.has_header("transfer-encoding"))
+    {
         has_transfer_encoding = true;
-
-        if (trim(it->second) == "chunked") has_chunked = true;
+        if (trim(request.header("transfer-encoding")->second) == "chunked")
+            has_chunked = true;
     }
 
     if (!has_transfer_encoding) return true;

--- a/src/ConnectionManager/Connection.cpp
+++ b/src/ConnectionManager/Connection.cpp
@@ -21,6 +21,9 @@ Connection::Connection(const ConfigServer* const config, int socket)
       _read_index(0),
       _write_buffer(),
       _write_index(0),
+      _is_chunked(false),
+      _chunk_size(0),
+      _chunk_received(0),
       _has_pending_cgi(false) {
     assert(config && "ConfigServer pointer");
     assert(socket > 2 && "Valid Socket Number");

--- a/src/RequestParser/request_parser.cpp
+++ b/src/RequestParser/request_parser.cpp
@@ -137,6 +137,7 @@ RequestStatus Connection::parse_headers() {
         return _request.status();
     }
 
+    if (!handle_chunked_encoding_header(_request)) return _request.status();
     if (_request.has_header("content-length"))
         handle_content_length_header(_request, _config->client_max_body_size);
 
@@ -190,6 +191,8 @@ RequestStatus Connection::resolve_location() {
 
 RequestStatus Connection::parse_body() {
     assert(_request.status() == REQ_HEADERS);
+
+    if (_is_chunked) return parse_chunked_body();
 
     if (_request.content_length() <= 0) {
         _request.set_status(REQ_PARSED);


### PR DESCRIPTION
This PR adds an additional check before looking for the content length header for POST requests. It also checks if it has both chunked encoding AND content length headers for invalid requests.

If it detects chunked encoding, parse_body will `parse_chunked_body()` early instead.

You can test it by making a regular curl POST request with a transfer-encoding: chunked header, or by sending the request in chunked format directly.

```
curl --http1.1 \
  -H "Transfer-Encoding: chunked" \
  -d 'Hello world' \
  http://127.0.0.1:8080/cgi-bin/script.py
```
```
{
  printf 'POST /cgi-bin/script.py HTTP/1.1\r\nHost: localhost:10080\r\nTransfer-Encoding: chunked\r\n\r\n';
  sleep 1;
  printf '5\r\nHel';
  sleep 1;
  printf 'lo\r\n6\r\n Wo';
  sleep 1;
  printf 'rld\r\n0\r\n\r\n';
} | timeout 10 nc 127.0.0.1 10080
```
