### PR TITLE
Bug/ftgetcwd 42 dump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,9 @@ CXXFLAGS	=	-Wall \
 				-MMD \
 				-MP \
 				-std=c++98 \
-				-g
+				-g \
+				-fstandalone-debug \
+				-O0
 RM			=	rm
 RMFLAGS		=	-f
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ CXXFLAGS	=	-Wall \
 				-MP \
 				-std=c++98 \
 				-g \
-				-fstandalone-debug \
 				-O0
 RM			=	rm
 RMFLAGS		=	-f

--- a/src/helpers/getcwd.cpp
+++ b/src/helpers/getcwd.cpp
@@ -65,7 +65,7 @@ std::string ft_getcwd() {
             directory_entry = readdir(directory_stream);
             if (stat(directory_entry->d_name, &stat_results) == -1) throw std::exception();
         }
-        if (errno != 0) {
+        if (directory_entry == NULL || errno != 0) {  // Looked at all entries without a match
             closedir(directory_stream);
             throw std::exception();
         }

--- a/src/helpers/getcwd.cpp
+++ b/src/helpers/getcwd.cpp
@@ -54,7 +54,7 @@ std::string ft_getcwd() {
         struct dirent* directory_entry = readdir(directory_stream);
 
         struct stat stat_results;
-        stat(directory_entry->d_name, &stat_results);
+        if (stat(directory_entry->d_name, &stat_results) == -1) throw std::exception();
         while (directory_entry != NULL) {
             if (stat_results.st_ino == current_id.second &&
                 stat_results.st_dev == current_id.first) {
@@ -63,6 +63,7 @@ std::string ft_getcwd() {
                 break;
             }
             directory_entry = readdir(directory_stream);
+            if (stat(directory_entry->d_name, &stat_results) == -1) throw std::exception();
         }
         if (errno != 0) {
             closedir(directory_stream);

--- a/src/helpers/getcwd.cpp
+++ b/src/helpers/getcwd.cpp
@@ -52,8 +52,12 @@ std::string ft_getcwd() {
         if (!directory_stream) throw std::exception();
         errno = 0;  // Set to 0 to distinguish readdir errors from end of stream
         struct dirent* directory_entry = readdir(directory_stream);
+
+        struct stat stat_results;
+        stat(directory_entry->d_name, &stat_results);
         while (directory_entry != NULL) {
-            if (directory_entry->d_ino == current_id.second) {
+            if (stat_results.st_ino == current_id.second &&
+                stat_results.st_dev == current_id.first) {
                 // If the inode is the same, we found the last directory we were in
                 path_elements.push_back(directory_entry->d_name);
                 break;
@@ -74,6 +78,8 @@ std::string ft_getcwd() {
         path.append("/");
         path.append(*element);
     }
+
+    std::cerr << path << std::endl;
 
     if (chdir(path.c_str()) == -1) throw std::exception();
     return path;

--- a/src/helpers/getcwd.cpp
+++ b/src/helpers/getcwd.cpp
@@ -80,8 +80,6 @@ std::string ft_getcwd() {
         path.append(*element);
     }
 
-    std::cerr << path << std::endl;
-
     if (chdir(path.c_str()) == -1) throw std::exception();
     return path;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ int main(int argc, char** argv) {
         working_directory = ft_getcwd();
     } catch (...) {
         std::cerr << "[!] - Failed to get working directory of webserv." << std::endl;
+        std::cerr << "[!] - Reason: " << strerror(errno) << std::endl;
         return 2;
     }
 


### PR DESCRIPTION
This function fixes the `ft_getcwd` helper to use `stat` instead of `readdir` for inode resolution.

This fixes a bug when trying to launch webserv on 42 dumps with special mounted filesystems, where readdir wouldn't do the resolution of inodes properly, leading to incorrect computed paths.