### PR TITLE
Bug/forbidden errno

### DIFF
--- a/src/Cgi/CgiHandler.cpp
+++ b/src/Cgi/CgiHandler.cpp
@@ -1,6 +1,5 @@
 #include "CgiHandler.hpp"
 
-#include <errno.h>
 #include <signal.h>
 #include <string.h>
 #include <sys/epoll.h>
@@ -90,7 +89,6 @@ void CgiHandler::read_stdout() {
             _stdout_eof = true;
             break;
         } else {
-            if (errno == EINTR) continue;
             break;
         }
     }
@@ -110,7 +108,6 @@ void CgiHandler::read_stderr() {
             _stderr_eof = true;
             break;
         } else {
-            if (errno == EINTR) continue;
             break;
         }
     }

--- a/src/Cgi/cgi_pipes.cpp
+++ b/src/Cgi/cgi_pipes.cpp
@@ -1,7 +1,6 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#include <cerrno>
 #include <cstdlib>
 #include <cstring>
 

--- a/src/ConnectionManager/Connection.cpp
+++ b/src/ConnectionManager/Connection.cpp
@@ -70,21 +70,16 @@ ssize_t Connection::receive_data() {
     char    buffer[RECV_SIZE];
     ssize_t total = 0;
 
-    while (true) {
-        ssize_t n = recv(_socket, buffer, sizeof(buffer), 0);
-        if (n > 0) {
-            _read_buffer.append(buffer, static_cast<size_t>(n));
-            total += n;
-        } else if (n == 0) {
-            // closing client
-            Logger(LOG_GENERAL) << "[CONN " << _socket << "] client closed recv0";
-            return 0;
-        } else {
-            // FIXME checking errno after a read/write is forbidden
-            if (errno == EAGAIN || errno == EWOULDBLOCK) break;  // nothing to read
-            Logger(LOG_ERROR) << "[Connection::receive_data] recv: " << std::strerror(errno);
-            return -1;
-        }
+    ssize_t n = recv(_socket, buffer, sizeof(buffer), 0);
+    if (n > 0) {
+        _read_buffer.append(buffer, static_cast<size_t>(n));
+        total += n;
+    } else if (n == 0) {
+        // closing client
+        Logger(LOG_GENERAL) << "[CONN " << _socket << "] client closed recv0";
+        return 0;
+    } else {
+        return -1;
     }
 
     return total;

--- a/src/ConnectionManager/ConnectionHandler.cpp
+++ b/src/ConnectionManager/ConnectionHandler.cpp
@@ -155,7 +155,6 @@ void ConnectionHandler::clear_cgi_handler() {
 bool ConnectionHandler::handle_event(ConnectionManager& manager, uint32_t events) {
     const Request&  request = _conn.request();
     const Response& response = _conn.response();
-    Logger(LOG_DEBUG) << "[!] - Response status: " << response.status();
 
     if (events & (EPOLLERR | EPOLLHUP)) {
         Logger(LOG_ERROR) << "[CONN " << _fd << "] Error: Wrong epoll event";

--- a/src/RequestProcessor/request_processor.cpp
+++ b/src/RequestProcessor/request_processor.cpp
@@ -1,6 +1,5 @@
 #include <unistd.h>
 
-#include <cerrno>
 #include <cstring>
 #include <string>
 


### PR DESCRIPTION
This PR removes two forbidden errno checks. One after `recv` in `Connection::receive_data`, and another in `CgiHandler.cpp`.

Fixes #110.